### PR TITLE
[FIX] #2 - view와 viewmodel을 컨테이너에서 제외

### DIFF
--- a/MyKkumi/MyKkumi/App/SceneDelegate.swift
+++ b/MyKkumi/MyKkumi/App/SceneDelegate.swift
@@ -17,10 +17,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScence = (scene as? UIWindowScene) else { return }
         
         injector.assemble([BasicAssembly(),
-                          BasicDataAssembly(),
-                          ViewAssembly()])
+                          BasicDataAssembly()])
         
-        let viewController = injector.resolve(ViewController.self)
+        let viewmodel = ViewModel(basicUsecase: injector.resolve(BasicUsecase.self))
+        let viewController = ViewController(viewModel: viewmodel)
         window = .init(windowScene: windowScence)
         window?.rootViewController = viewController
         window?.makeKeyAndVisible()

--- a/MyKkumi/MyKkumi/Domain/UseCase/BasicUsecase.swift
+++ b/MyKkumi/MyKkumi/Domain/UseCase/BasicUsecase.swift
@@ -9,7 +9,7 @@ import Foundation
 import RxSwift
 
 public protocol BasicUsecase {
-    func getHelloWorld() -> Observable<String?>
+    func getHelloWorld() -> Single<String?>
 }
 
 public final class DefaultBasicUsecase : BasicUsecase {
@@ -19,9 +19,8 @@ public final class DefaultBasicUsecase : BasicUsecase {
         self.repository = repository
     }
     
-    public func getHelloWorld() -> Observable<String?> {
+    public func getHelloWorld() -> Single<String?> {
         return repository.getHelloWorld()
-            .asObservable()
             .map{result -> String? in
                 switch result {
                 case .success(let helloWrld) :

--- a/MyKkumi/MyKkumi/Presentation/Basic/ExampleView/ViewController.swift
+++ b/MyKkumi/MyKkumi/Presentation/Basic/ExampleView/ViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 import RxSwift
 
 class ViewController: UIViewController {
-    var viewModel : ViewModel
+    var viewModel : HelloWordData
     private let disposeBag = DisposeBag()
     
     private lazy var helloWord : UILabel = {
@@ -45,6 +45,7 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .white
         bindRx()
+        layout()
     }
     
     func bindRx() {
@@ -56,7 +57,9 @@ class ViewController: UIViewController {
         hellowordButton.rx.tap
             .bind(to: self.viewModel.buttontaps)
             .disposed(by: disposeBag)
-        
+    }
+    
+    func layout() {
         view.addSubview(helloWord)
         view.addSubview(hellowordButton)
         


### PR DESCRIPTION
## 구현내용
### ㅇ 1. bind기능과 layout기능 구분
- 레이아웃 코드를 bindRx함수에서 분리

### ㅇ 2. view와 viewModel을 컨테이너에서 제외
- DI컨테이너에서 해당 2가지 제외하였습니다.
- 제외한 이후 SceneDelegate에서 viewController를 새롭게 생성하였는데 해당 부분이 맞는지 아직 . 잘모르겠습니다.

### ㅇ 3. API 호출시 Observable이 아닌 Single 사용하도록 변경
- Observable의 경우 한번의 success이후에도 그대로 유지는것을 확인하였습니다.
- Single의 경우 한번의 success 이후에 onDisposed까지 수행되는 것을 확인하였습니다.

## 고민사항
### ㅇ 1. view와 viewModel이 컨테이너에 없는 경우
- 해당 상황에서 view가 viewModel을 생성하여 사용하지 않는 방법에 대하여 정확히 알지 못하였습니다. 현재 사용하는 방법이 정확한 방법인지 정확히 알지 못하겠습니다.

## 기타
연습용 Branch를 basesettingDI로 잡고 그 아래로 새로운 브랜치를 만들어 이론적인 연습을 해보고자 하였습니다!