### PR TITLE
[MERGE] Keychain 관련 리펙토링

### DIFF
--- a/MyKkumi/MyKkumi.xcodeproj/project.pbxproj
+++ b/MyKkumi/MyKkumi.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		D2ABCE3B2C3434140035F7A1 /* PostRespository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2ABCE3A2C3434140035F7A1 /* PostRespository.swift */; };
 		D2ABCE3D2C3434F00035F7A1 /* PostUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2ABCE3C2C3434F00035F7A1 /* PostUsecase.swift */; };
 		D2C79F272C58FF1200E41D8C /* RequestInterceptorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F262C58FF1200E41D8C /* RequestInterceptorExtension.swift */; };
+		D2C79F2A2C5A1A7600E41D8C /* MakePostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F292C5A1A7600E41D8C /* MakePostViewController.swift */; };
+		D2C79F2C2C5A1AB200E41D8C /* MakePostViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F2B2C5A1AB200E41D8C /* MakePostViewModel.swift */; };
 		D2E4594F2C1DB41500DB0756 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D2E4594E2C1DB41500DB0756 /* LaunchScreen.storyboard */; };
 		D2E459542C1E1A6300DB0756 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E459532C1E1A6300DB0756 /* ViewModel.swift */; };
 		D2E4595C2C1E383D00DB0756 /* BasicCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E4595B2C1E383D00DB0756 /* BasicCommon.swift */; };
@@ -189,6 +191,8 @@
 		D2ABCE3A2C3434140035F7A1 /* PostRespository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRespository.swift; sourceTree = "<group>"; };
 		D2ABCE3C2C3434F00035F7A1 /* PostUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostUsecase.swift; sourceTree = "<group>"; };
 		D2C79F262C58FF1200E41D8C /* RequestInterceptorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestInterceptorExtension.swift; sourceTree = "<group>"; };
+		D2C79F292C5A1A7600E41D8C /* MakePostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakePostViewController.swift; sourceTree = "<group>"; };
+		D2C79F2B2C5A1AB200E41D8C /* MakePostViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakePostViewModel.swift; sourceTree = "<group>"; };
 		D2E4594E2C1DB41500DB0756 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D2E459532C1E1A6300DB0756 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		D2E4595B2C1E383D00DB0756 /* BasicCommon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicCommon.swift; sourceTree = "<group>"; };
@@ -571,6 +575,15 @@
 			path = Post;
 			sourceTree = "<group>";
 		};
+		D2C79F282C5A1A2900E41D8C /* Post */ = {
+			isa = PBXGroup;
+			children = (
+				D2C79F292C5A1A7600E41D8C /* MakePostViewController.swift */,
+				D2C79F2B2C5A1AB200E41D8C /* MakePostViewModel.swift */,
+			);
+			path = Post;
+			sourceTree = "<group>";
+		};
 		D2E459482C1DB1C000DB0756 /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -628,6 +641,7 @@
 		D2E4594D2C1DB20A00DB0756 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				D2C79F282C5A1A2900E41D8C /* Post */,
 				D21FB54B2C3E7AB100927905 /* Auth */,
 				D2ABCDEE2C2AB2FC0035F7A1 /* Extension */,
 				D2E4594A2C1DB1F900DB0756 /* CommonUI */,
@@ -944,6 +958,7 @@
 				D2ABCDFD2C2BFE370035F7A1 /* BannerCollectionView.swift in Sources */,
 				D21FB5482C3BEE7F00927905 /* TestViewModel.swift in Sources */,
 				D2ED95422C46AF20004DA169 /* AuthRepositoryProtocol.swift in Sources */,
+				D2C79F2C2C5A1AB200E41D8C /* MakePostViewModel.swift in Sources */,
 				D230F9252C1D714C00C43797 /* AppDelegate.swift in Sources */,
 				D2ABCE162C2D4BF50035F7A1 /* Image+TextExtension.swift in Sources */,
 				D2ED954F2C4E1B76004DA169 /* CategoryCollectionView.swift in Sources */,
@@ -963,6 +978,7 @@
 				D2ABCDF22C2AB5470035F7A1 /* Colors.swift in Sources */,
 				D2ABCDCE2C2A66910035F7A1 /* BasicRespository.swift in Sources */,
 				D2ABCE082C2D256B0035F7A1 /* BannerUsecase.swift in Sources */,
+				D2C79F2A2C5A1A7600E41D8C /* MakePostViewController.swift in Sources */,
 				D2ABCE0E2C2D2DB10035F7A1 /* BannerDataSource.swift in Sources */,
 				D2ABCDCB2C2A66350035F7A1 /* BasicUsecase.swift in Sources */,
 				D2C79F272C58FF1200E41D8C /* RequestInterceptorExtension.swift in Sources */,

--- a/MyKkumi/MyKkumi.xcodeproj/project.pbxproj
+++ b/MyKkumi/MyKkumi.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		D2C79F272C58FF1200E41D8C /* RequestInterceptorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F262C58FF1200E41D8C /* RequestInterceptorExtension.swift */; };
 		D2C79F2A2C5A1A7600E41D8C /* MakePostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F292C5A1A7600E41D8C /* MakePostViewController.swift */; };
 		D2C79F2C2C5A1AB200E41D8C /* MakePostViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F2B2C5A1AB200E41D8C /* MakePostViewModel.swift */; };
+		D2C79F2E2C5A2D5000E41D8C /* SelectedImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F2D2C5A2D5000E41D8C /* SelectedImageCell.swift */; };
 		D2E4594F2C1DB41500DB0756 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D2E4594E2C1DB41500DB0756 /* LaunchScreen.storyboard */; };
 		D2E459542C1E1A6300DB0756 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E459532C1E1A6300DB0756 /* ViewModel.swift */; };
 		D2E4595C2C1E383D00DB0756 /* BasicCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E4595B2C1E383D00DB0756 /* BasicCommon.swift */; };
@@ -193,6 +194,7 @@
 		D2C79F262C58FF1200E41D8C /* RequestInterceptorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestInterceptorExtension.swift; sourceTree = "<group>"; };
 		D2C79F292C5A1A7600E41D8C /* MakePostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakePostViewController.swift; sourceTree = "<group>"; };
 		D2C79F2B2C5A1AB200E41D8C /* MakePostViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakePostViewModel.swift; sourceTree = "<group>"; };
+		D2C79F2D2C5A2D5000E41D8C /* SelectedImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedImageCell.swift; sourceTree = "<group>"; };
 		D2E4594E2C1DB41500DB0756 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D2E459532C1E1A6300DB0756 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		D2E4595B2C1E383D00DB0756 /* BasicCommon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicCommon.swift; sourceTree = "<group>"; };
@@ -571,6 +573,7 @@
 				D2ABCE2A2C33C4D90035F7A1 /* PostImageCollectionView.swift */,
 				D2ABCE2C2C33C53A0035F7A1 /* PostImageCollectionViewCell.swift */,
 				D2ABCE302C33C64C0035F7A1 /* PostImageCollectionViewFlowLayout.swift */,
+				D2C79F2D2C5A2D5000E41D8C /* SelectedImageCell.swift */,
 			);
 			path = Post;
 			sourceTree = "<group>";
@@ -1016,6 +1019,7 @@
 				D2ABCE032C2D1E490035F7A1 /* BannerVO.swift in Sources */,
 				D2ABCDEB2C2A9D8A0035F7A1 /* MypageViewController.swift in Sources */,
 				D2ABCE392C3433C10035F7A1 /* PostRespositoryProtocol.swift in Sources */,
+				D2C79F2E2C5A2D5000E41D8C /* SelectedImageCell.swift in Sources */,
 				D2ABCE182C2D4E370035F7A1 /* DataAssembly.swift in Sources */,
 				D2ABCE1C2C2D94EE0035F7A1 /* DetailBannerViewController.swift in Sources */,
 				D2ABCDD82C2A6AE10035F7A1 /* BasicAssembly.swift in Sources */,

--- a/MyKkumi/MyKkumi.xcodeproj/project.pbxproj
+++ b/MyKkumi/MyKkumi.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		D2C79F2A2C5A1A7600E41D8C /* MakePostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F292C5A1A7600E41D8C /* MakePostViewController.swift */; };
 		D2C79F2C2C5A1AB200E41D8C /* MakePostViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F2B2C5A1AB200E41D8C /* MakePostViewModel.swift */; };
 		D2C79F2E2C5A2D5000E41D8C /* SelectedImageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F2D2C5A2D5000E41D8C /* SelectedImageCell.swift */; };
+		D2C79F302C5A6FB200E41D8C /* SelectedImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F2F2C5A6FB200E41D8C /* SelectedImageViewModel.swift */; };
+		D2C79F322C5A70B700E41D8C /* AddImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F312C5A70B700E41D8C /* AddImageViewModel.swift */; };
 		D2E4594F2C1DB41500DB0756 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D2E4594E2C1DB41500DB0756 /* LaunchScreen.storyboard */; };
 		D2E459542C1E1A6300DB0756 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E459532C1E1A6300DB0756 /* ViewModel.swift */; };
 		D2E4595C2C1E383D00DB0756 /* BasicCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E4595B2C1E383D00DB0756 /* BasicCommon.swift */; };
@@ -195,6 +197,8 @@
 		D2C79F292C5A1A7600E41D8C /* MakePostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakePostViewController.swift; sourceTree = "<group>"; };
 		D2C79F2B2C5A1AB200E41D8C /* MakePostViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MakePostViewModel.swift; sourceTree = "<group>"; };
 		D2C79F2D2C5A2D5000E41D8C /* SelectedImageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedImageCell.swift; sourceTree = "<group>"; };
+		D2C79F2F2C5A6FB200E41D8C /* SelectedImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedImageViewModel.swift; sourceTree = "<group>"; };
+		D2C79F312C5A70B700E41D8C /* AddImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddImageViewModel.swift; sourceTree = "<group>"; };
 		D2E4594E2C1DB41500DB0756 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D2E459532C1E1A6300DB0756 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		D2E4595B2C1E383D00DB0756 /* BasicCommon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicCommon.swift; sourceTree = "<group>"; };
@@ -583,6 +587,8 @@
 			children = (
 				D2C79F292C5A1A7600E41D8C /* MakePostViewController.swift */,
 				D2C79F2B2C5A1AB200E41D8C /* MakePostViewModel.swift */,
+				D2C79F2F2C5A6FB200E41D8C /* SelectedImageViewModel.swift */,
+				D2C79F312C5A70B700E41D8C /* AddImageViewModel.swift */,
 			);
 			path = Post;
 			sourceTree = "<group>";
@@ -972,6 +978,7 @@
 				D2ABCE142C2D2F490035F7A1 /* NetworkConfiguration.swift in Sources */,
 				D2ED95532C4E26E4004DA169 /* CategoryCollectionViewFlowLayout.swift in Sources */,
 				D2ABCDD22C2A68940035F7A1 /* BasicDataSource.swift in Sources */,
+				D2C79F302C5A6FB200E41D8C /* SelectedImageViewModel.swift in Sources */,
 				D21FB54F2C3E820100927905 /* AuthViewModel.swift in Sources */,
 				D2ABCDF92C2BE55B0035F7A1 /* BaseViewController.swift in Sources */,
 				D2828C3B2C53A5100036DFDD /* RootWindow.swift in Sources */,
@@ -982,6 +989,7 @@
 				D2ABCDCE2C2A66910035F7A1 /* BasicRespository.swift in Sources */,
 				D2ABCE082C2D256B0035F7A1 /* BannerUsecase.swift in Sources */,
 				D2C79F2A2C5A1A7600E41D8C /* MakePostViewController.swift in Sources */,
+				D2C79F322C5A70B700E41D8C /* AddImageViewModel.swift in Sources */,
 				D2ABCE0E2C2D2DB10035F7A1 /* BannerDataSource.swift in Sources */,
 				D2ABCDCB2C2A66350035F7A1 /* BasicUsecase.swift in Sources */,
 				D2C79F272C58FF1200E41D8C /* RequestInterceptorExtension.swift in Sources */,
@@ -1193,6 +1201,8 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MyKkumi/Resources/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "포스트 등록, 프로필 설정을 목적으로 마이꾸미의 회원님의 카메라에 대한 엑세스 권한을 요청합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "포스트 등록, 프로필 설정을 목적으로 마이꾸미의 회원님의 사진 보관함에 대한 엑세스 권한을 요청합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -1226,6 +1236,8 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MyKkumi/Resources/Info.plist;
+				INFOPLIST_KEY_NSCameraUsageDescription = "포스트 등록, 프로필 설정을 목적으로 마이꾸미의 회원님의 카메라에 대한 엑세스 권한을 요청합니다.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "포스트 등록, 프로필 설정을 목적으로 마이꾸미의 회원님의 사진 보관함에 대한 엑세스 권한을 요청합니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/MyKkumi/MyKkumi.xcodeproj/project.pbxproj
+++ b/MyKkumi/MyKkumi.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		D2ABCE392C3433C10035F7A1 /* PostRespositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2ABCE382C3433C10035F7A1 /* PostRespositoryProtocol.swift */; };
 		D2ABCE3B2C3434140035F7A1 /* PostRespository.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2ABCE3A2C3434140035F7A1 /* PostRespository.swift */; };
 		D2ABCE3D2C3434F00035F7A1 /* PostUsecase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2ABCE3C2C3434F00035F7A1 /* PostUsecase.swift */; };
+		D2C79F272C58FF1200E41D8C /* RequestInterceptorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C79F262C58FF1200E41D8C /* RequestInterceptorExtension.swift */; };
 		D2E4594F2C1DB41500DB0756 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D2E4594E2C1DB41500DB0756 /* LaunchScreen.storyboard */; };
 		D2E459542C1E1A6300DB0756 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E459532C1E1A6300DB0756 /* ViewModel.swift */; };
 		D2E4595C2C1E383D00DB0756 /* BasicCommon.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E4595B2C1E383D00DB0756 /* BasicCommon.swift */; };
@@ -187,6 +188,7 @@
 		D2ABCE382C3433C10035F7A1 /* PostRespositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRespositoryProtocol.swift; sourceTree = "<group>"; };
 		D2ABCE3A2C3434140035F7A1 /* PostRespository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRespository.swift; sourceTree = "<group>"; };
 		D2ABCE3C2C3434F00035F7A1 /* PostUsecase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostUsecase.swift; sourceTree = "<group>"; };
+		D2C79F262C58FF1200E41D8C /* RequestInterceptorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestInterceptorExtension.swift; sourceTree = "<group>"; };
 		D2E4594E2C1DB41500DB0756 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D2E459532C1E1A6300DB0756 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		D2E4595B2C1E383D00DB0756 /* BasicCommon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicCommon.swift; sourceTree = "<group>"; };
@@ -607,6 +609,7 @@
 				D21030642C2178220059CACA /* Protocols */,
 				D21030612C2177C50059CACA /* Service */,
 				D2ED954B2C4CD79E004DA169 /* KeychainHelper.swift */,
+				D2C79F262C58FF1200E41D8C /* RequestInterceptorExtension.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -962,6 +965,7 @@
 				D2ABCE082C2D256B0035F7A1 /* BannerUsecase.swift in Sources */,
 				D2ABCE0E2C2D2DB10035F7A1 /* BannerDataSource.swift in Sources */,
 				D2ABCDCB2C2A66350035F7A1 /* BasicUsecase.swift in Sources */,
+				D2C79F272C58FF1200E41D8C /* RequestInterceptorExtension.swift in Sources */,
 				D2ABCDFF2C2BFF330035F7A1 /* BannerCollectionCell.swift in Sources */,
 				D210306D2C21864B0059CACA /* GetTitle.swift in Sources */,
 				D21030662C2178530059CACA /* BasicProtocol.swift in Sources */,

--- a/MyKkumi/MyKkumi/App/Application/AppDelegate.swift
+++ b/MyKkumi/MyKkumi/App/Application/AppDelegate.swift
@@ -17,35 +17,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         KakaoSDK.initSDK(appKey: NetworkConfiguration.kakaoKeyValue)
-        if let refreshToken = KeychainHelper.shared.load(key: "refreshToken") {
-            print("refreshToken : \(refreshToken)")
-            authProvider.rx.request(.refreshToken(refreshToken))
-                .filterSuccessfulStatusCodes()
-                .map { response in
-                    let token = try JSONDecoder().decode(ReAccessToken.self, from: response.data)
-                    return token.accessToken
-                }
-                .subscribe(onSuccess: { accessToken in
-                    let accessTokenSave = KeychainHelper.shared.save(accessToken, key: "accessToken")
-                    if !accessTokenSave {
-                        KeychainHelper.shared.delete(key: "accessToken")
-                        KeychainHelper.shared.delete(key: "refreshToken")
-                    }
-                }, onFailure: {error in
-                    KeychainHelper.shared.delete(key: "accessToken")
-                    KeychainHelper.shared.delete(key: "refreshToken")
-                })
-                .disposed(by: disposBag)
-        } else {
-            let accessToken = KeychainHelper.shared.load(key: "accessToken")
-            let refreshToken = KeychainHelper.shared.load(key: "refreshToken")
-            print("accessToken : \(accessToken)")
-            print("refreshToken : \(refreshToken)")
-            
-            KeychainHelper.shared.delete(key: "accessToken")
-            
-            
-        }
         
         return true
     }

--- a/MyKkumi/MyKkumi/App/Application/AppDelegate.swift
+++ b/MyKkumi/MyKkumi/App/Application/AppDelegate.swift
@@ -8,12 +8,39 @@
 import UIKit
 import KakaoSDKCommon
 import Swinject
+import RxSwift
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    
+    let disposBag = DisposeBag()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         KakaoSDK.initSDK(appKey: NetworkConfiguration.kakaoKeyValue)
+        if let refreshToken = KeychainHelper.shared.load(service: "refreshToken") {
+            print("refreshToken : \(refreshToken)")
+            let reToken = String(data : refreshToken, encoding: .utf8)!
+            authProvider.rx.request(.getToken(reToken))
+                .filterSuccessfulStatusCodes()
+                .map { response in
+                    let token = try JSONDecoder().decode(ReAccessToken.self, from: response.data)
+                    return token.accessToken
+                }
+                .subscribe(onSuccess: { accessToken in
+                    let accessTokenData = accessToken.data(using: .utf8)!
+                    let accessTokenSave = KeychainHelper.shared.save(accessTokenData, service: "accessToken")
+                    if !accessTokenSave {
+                        KeychainHelper.shared.delete(service: "accessToken")
+                        KeychainHelper.shared.delete(service: "refreshToken")
+                    }
+                }, onFailure: {error in
+                    KeychainHelper.shared.delete(service: "accessToken")
+                    KeychainHelper.shared.delete(service: "refreshToken")
+                })
+                .disposed(by: disposBag)
+                
+        }
+        
         return true
     }
 

--- a/MyKkumi/MyKkumi/Data/DataSource/AuthDataSoucrce.swift
+++ b/MyKkumi/MyKkumi/Data/DataSource/AuthDataSoucrce.swift
@@ -24,8 +24,8 @@ public class DefaultAuthDataSource : AuthDataSource {
             .filterSuccessfulStatusCodes()
             .map {response in
                 let tokens = try JSONDecoder().decode(AuthVO.self, from: response.data)
-                let accessTokenSaved = KeychainHelper.shared.save(tokens.accessToken.data(using: .utf8)!, service: "accessToken")
-                let refreshTokenSaved = KeychainHelper.shared.save(tokens.refreshToken.data(using: .utf8)!, service: "refreshToken")
+                let accessTokenSaved = KeychainHelper.shared.save(tokens.accessToken, key: "accessToken")
+                let refreshTokenSaved = KeychainHelper.shared.save(tokens.refreshToken, key: "refreshToken")
                 
                 if accessTokenSaved && refreshTokenSaved {
                     return .success(true)
@@ -100,8 +100,8 @@ public class DefaultAuthDataSource : AuthDataSource {
             .map {response in
                 print(response)
                 let tokens = try JSONDecoder().decode(AuthVO.self, from: response.data)
-                let accessTokenSaved = KeychainHelper.shared.save(tokens.accessToken.data(using: .utf8)!, service: "accessToken")
-                let refreshTokenSaved = KeychainHelper.shared.save(tokens.refreshToken.data(using: .utf8)!, service: "refreshToken")
+                let accessTokenSaved = KeychainHelper.shared.save(tokens.accessToken, key: "accessToken")
+                let refreshTokenSaved = KeychainHelper.shared.save(tokens.refreshToken, key: "refreshToken")
                 
                 if accessTokenSaved && refreshTokenSaved {
                     return .success(true)

--- a/MyKkumi/MyKkumi/Data/KeychainHelper.swift
+++ b/MyKkumi/MyKkumi/Data/KeychainHelper.swift
@@ -17,8 +17,6 @@ class KeychainHelper {
         
         let status = SecItemAdd(query, nil)
         
-        print("key : \(key) , status : \(status)")
-        
         return status == errSecSuccess
     }
     

--- a/MyKkumi/MyKkumi/Data/KeychainHelper.swift
+++ b/MyKkumi/MyKkumi/Data/KeychainHelper.swift
@@ -6,11 +6,10 @@ class KeychainHelper {
     
     private init() {}
     
-    func save(_ data: Data, service: String, account: String) -> Bool {
+    func save(_ data: Data, service: String) -> Bool {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
             kSecValueData as String: data
         ]
         
@@ -20,11 +19,10 @@ class KeychainHelper {
         return status == errSecSuccess
     }
     
-    func load(service: String, account: String) -> Data? {
+    func load(service: String) -> Data? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
             kSecReturnData as String: kCFBooleanTrue!,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
@@ -39,11 +37,10 @@ class KeychainHelper {
         return nil
     }
     
-    func delete(service: String, account: String) {
+    func delete(service: String) {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
-            kSecAttrAccount as String: account
         ]
         
         SecItemDelete(query as CFDictionary)

--- a/MyKkumi/MyKkumi/Data/KeychainHelper.swift
+++ b/MyKkumi/MyKkumi/Data/KeychainHelper.swift
@@ -6,43 +6,48 @@ class KeychainHelper {
     
     private init() {}
     
-    func save(_ data: Data, service: String) -> Bool {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecValueData as String: data
+    func save(_ token: String, key: String) -> Bool {
+        let query : NSDictionary = [
+            kSecClass : kSecClassGenericPassword,
+            kSecAttrService : key,
+            kSecValueData : token.data(using: .utf8, allowLossyConversion : false)!
         ]
         
-        SecItemDelete(query as CFDictionary)
-        let status = SecItemAdd(query as CFDictionary, nil)
+        SecItemDelete(query)
+        
+        let status = SecItemAdd(query, nil)
+        
+        print("key : \(key) , status : \(status)")
         
         return status == errSecSuccess
     }
     
-    func load(service: String) -> Data? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecReturnData as String: kCFBooleanTrue!,
-            kSecMatchLimit as String: kSecMatchLimitOne
+    func load(key: String) -> String? {
+        let query: NSDictionary = [
+            kSecClass : kSecClassGenericPassword,
+            kSecAttrService : key,
+            kSecReturnAttributes : true,
+            kSecReturnData : true
         ]
         
-        var dataTypeRef: AnyObject?
-        let status: OSStatus = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
+        var dataTypeRef: CFTypeRef?
+        let status = SecItemCopyMatching(query , &dataTypeRef)
         
         if status == errSecSuccess {
-            return dataTypeRef as? Data
+            guard let checkedItem = dataTypeRef,
+                  let token = checkedItem[kSecValueData] as? Data else { return nil }
+            return String(data: token, encoding: String.Encoding.utf8)
         }
         
         return nil
     }
     
-    func delete(service: String) {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
+    func delete(key: String) {
+        let query: NSDictionary = [
+            kSecClass : kSecClassGenericPassword,
+            kSecAttrService : key
         ]
         
-        SecItemDelete(query as CFDictionary)
+        SecItemDelete(query)
     }
 }

--- a/MyKkumi/MyKkumi/Data/Repository/AuthRepository.swift
+++ b/MyKkumi/MyKkumi/Data/Repository/AuthRepository.swift
@@ -31,4 +31,8 @@ public class DefaultAuthRepository : AuthRepository {
     public func patchUserData(_ user: PatchUserVO) -> Single<Result<UserVO, AuthError>> {
         return dataSource.patchUserData(user)
     }
+    
+    public func refreshToken() {
+        dataSource.refreshToken()
+    }
 }

--- a/MyKkumi/MyKkumi/Data/Repository/AuthRepository.swift
+++ b/MyKkumi/MyKkumi/Data/Repository/AuthRepository.swift
@@ -27,4 +27,8 @@ public class DefaultAuthRepository : AuthRepository {
     public func siginApple(_ auth: AppleAuth) -> RxSwift.Single<Result<Bool, AuthError>> {
         return dataSource.signinApple(auth)
     }
+    
+    public func patchUserData(_ user: PatchUserVO) -> Single<Result<UserVO, AuthError>> {
+        return dataSource.patchUserData(user)
+    }
 }

--- a/MyKkumi/MyKkumi/Data/RequestInterceptorExtension.swift
+++ b/MyKkumi/MyKkumi/Data/RequestInterceptorExtension.swift
@@ -43,7 +43,8 @@ class NetworkInterceptor : RequestInterceptor {
     
     private func refreshAccessToken() -> Single<Bool> {
         if let refreshToken = KeychainHelper.shared.load(key: "refreshToken") {
-            return authProvider.rx.request(.refreshToken(refreshToken))
+            let object = RefreshToekn(refreshToken: refreshToken)
+            return authProvider.rx.request(.refreshToken(object))
                 .filterSuccessfulStatusCodes()
                 .map { response in
                     let tokens = try JSONDecoder().decode(AuthVO.self, from: response.data)

--- a/MyKkumi/MyKkumi/Data/RequestInterceptorExtension.swift
+++ b/MyKkumi/MyKkumi/Data/RequestInterceptorExtension.swift
@@ -1,0 +1,60 @@
+//
+//  RequestInterceptorExtension.swift
+//  MyKkumi
+//
+//  Created by 최재혁 on 7/30/24.
+//
+
+import Foundation
+import Alamofire
+import RxSwift
+
+class NetworkInterceptor : RequestInterceptor {
+    let retryLimit = 5
+    let retryDelay : TimeInterval = 5
+    let disposeBag = DisposeBag()
+    
+    public func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        var urlRequest = urlRequest
+        var accessToken = ""
+        if let result = KeychainHelper.shared.load(service: "accessToken") {
+            accessToken = String(data : result, encoding: .utf8)!
+        }
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        completion(.success(urlRequest))
+    }
+
+    public func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+        let response = request.task?.response as? HTTPURLResponse
+        if let statusCode = response?.statusCode, statusCode == 401, request.retryCount < retryLimit {
+            refreshAccessToken()
+                .subscribe(onSuccess: { success in
+                    if success {
+                        completion(.retry)
+                    } else {
+                        completion(.doNotRetry)
+                    }
+                }, onFailure : {_  in
+                    completion(.doNotRetry)
+                })
+                .disposed(by: disposeBag)
+        }
+        completion(.doNotRetry)
+    }
+    
+    private func refreshAccessToken() -> Single<Bool> {
+        if let refreshData = KeychainHelper.shared.load(service: "refreshToken") {
+            let refreshToken = String(data: refreshData, encoding: .utf8)!
+            return authProvider.rx.request(.getToken(refreshToken))
+                .filterSuccessfulStatusCodes()
+                .map { response in
+                    let tokens = try JSONDecoder().decode(AuthVO.self, from: response.data)
+                    let accessTokenSaved = KeychainHelper.shared.save(tokens.accessToken.data(using: .utf8)!, service: "accessToken")
+                    return accessTokenSaved
+                }
+        } else {
+            return .just(false)
+        }
+    }
+}

--- a/MyKkumi/MyKkumi/Data/Service/Auth/AuthService.swift
+++ b/MyKkumi/MyKkumi/Data/Service/Auth/AuthService.swift
@@ -21,7 +21,7 @@ public enum Auth {
     case signinApple(AppleAuth)
     case getUserData
     case patchUser(PatchUserVO)
-    case refreshToken(String)
+    case refreshToken(RefreshToekn)
 }
 
 extension Auth : TargetType {

--- a/MyKkumi/MyKkumi/Data/Service/Auth/AuthService.swift
+++ b/MyKkumi/MyKkumi/Data/Service/Auth/AuthService.swift
@@ -21,7 +21,7 @@ public enum Auth {
     case signinApple(AppleAuth)
     case getUserData
     case patchUser(PatchUserVO)
-    case getToken(String)
+    case refreshToken(String)
 }
 
 extension Auth : TargetType {
@@ -33,14 +33,14 @@ extension Auth : TargetType {
         case .signinApple(_) : return NetworkConfiguration.signinApple
         case .getUserData : return NetworkConfiguration.getUserData
         case .patchUser(_) : return NetworkConfiguration.patchUser
-        case .getToken(_) : return NetworkConfiguration.getToken
+        case .refreshToken(_) : return NetworkConfiguration.getToken
         }
     }
     
     public var method : Moya.Method {
         switch self {
         case .getUserData : return .get
-        case .signinKakao(_), .signinApple(_), .getToken  : return .post
+        case .signinKakao(_), .signinApple(_), .refreshToken  : return .post
         case .patchUser(_) : return .patch
         }
     }
@@ -76,7 +76,7 @@ extension Auth : TargetType {
 //            }
             
             return .uploadMultipart(multipartData)
-        case .getToken(let refreshToken) :
+        case .refreshToken(let refreshToken) :
             return .requestJSONEncodable(refreshToken)
         }
     }
@@ -84,8 +84,7 @@ extension Auth : TargetType {
     public var headers : [String : String]? {
         switch self {
         case .patchUser(_) :
-            let accessTokenData = KeychainHelper.shared.load(service: "accessToken")!
-            let accessToken = String(data: accessTokenData, encoding: .utf8)!
+            let accessToken = KeychainHelper.shared.load(key: "accessToken")!
             return ["Content-Type" : "application/json",
                     "Authorization" : accessToken]
         default :

--- a/MyKkumi/MyKkumi/Domain/RepositoryProtocol/AuthRepositoryProtocol.swift
+++ b/MyKkumi/MyKkumi/Domain/RepositoryProtocol/AuthRepositoryProtocol.swift
@@ -11,4 +11,5 @@ public protocol AuthRepository {
     func signinKakao(auth: AuthVO) -> Single<Result<Bool, AuthError>>
     func kakaoAPICall() -> Single<Result<OAuthToken, AuthError>>
     func siginApple(_ auth : AppleAuth) -> Single<Result<Bool, AuthError>>
+    func patchUserData(_ user : PatchUserVO) -> Single<Result<UserVO, AuthError>>
 }

--- a/MyKkumi/MyKkumi/Domain/RepositoryProtocol/AuthRepositoryProtocol.swift
+++ b/MyKkumi/MyKkumi/Domain/RepositoryProtocol/AuthRepositoryProtocol.swift
@@ -12,4 +12,5 @@ public protocol AuthRepository {
     func kakaoAPICall() -> Single<Result<OAuthToken, AuthError>>
     func siginApple(_ auth : AppleAuth) -> Single<Result<Bool, AuthError>>
     func patchUserData(_ user : PatchUserVO) -> Single<Result<UserVO, AuthError>>
+    func refreshToken()
 }

--- a/MyKkumi/MyKkumi/Domain/UseCase/AuthUsecase.swift
+++ b/MyKkumi/MyKkumi/Domain/UseCase/AuthUsecase.swift
@@ -13,6 +13,7 @@ public protocol AuthUsecase {
     func kakaoAPICall() -> Single<Result<OAuthToken, AuthError>>
     func signinApple(_ auth : AppleAuth) -> Single<Result<Bool, AuthError>>
     func patchUserData(_ user : PatchUserVO) -> Single<Result<UserVO, AuthError>>
+    func refreshToken()
 }
 
 public final class DefaultAuthUsecase : AuthUsecase {
@@ -38,5 +39,9 @@ public final class DefaultAuthUsecase : AuthUsecase {
     
     public func patchUserData(_ user: PatchUserVO) -> Single<Result<UserVO, AuthError>> {
         return repository.patchUserData(user)
+    }
+    
+    public func refreshToken() {
+        repository.refreshToken()
     }
 }

--- a/MyKkumi/MyKkumi/Domain/UseCase/AuthUsecase.swift
+++ b/MyKkumi/MyKkumi/Domain/UseCase/AuthUsecase.swift
@@ -12,6 +12,7 @@ public protocol AuthUsecase {
     func signinKakao(auth: AuthVO) -> Single<Result<Bool, AuthError>>
     func kakaoAPICall() -> Single<Result<OAuthToken, AuthError>>
     func signinApple(_ auth : AppleAuth) -> Single<Result<Bool, AuthError>>
+    func patchUserData(_ user : PatchUserVO) -> Single<Result<UserVO, AuthError>>
 }
 
 public final class DefaultAuthUsecase : AuthUsecase {
@@ -33,5 +34,9 @@ public final class DefaultAuthUsecase : AuthUsecase {
     
     public func signinApple(_ auth: AppleAuth) -> RxSwift.Single<Result<Bool, AuthError>> {
         return repository.siginApple(auth)
+    }
+    
+    public func patchUserData(_ user: PatchUserVO) -> Single<Result<UserVO, AuthError>> {
+        return repository.patchUserData(user)
     }
 }

--- a/MyKkumi/MyKkumi/Domain/VO/AuthVO.swift
+++ b/MyKkumi/MyKkumi/Domain/VO/AuthVO.swift
@@ -105,6 +105,10 @@ public struct PatchUserVO  {
     }
 }
 
+public struct RefreshToekn : Codable {
+    let refreshToken : String
+}
+
 public struct ReAccessToken : Codable {
     let accessToken : String
     

--- a/MyKkumi/MyKkumi/Domain/VO/AuthVO.swift
+++ b/MyKkumi/MyKkumi/Domain/VO/AuthVO.swift
@@ -57,7 +57,7 @@ public struct AppleAuth : Codable {
 
 public struct UserVO : Codable {
     let nickname : String?
-    let email : String?
+    let email : String
     let introduction : String?
     let profilImage : String?
     
@@ -68,7 +68,7 @@ public struct UserVO : Codable {
         case profilImage
     }
     
-    public init(nickname: String?, email: String?, introduction: String?, profilImage: String?) {
+    public init(nickname: String?, email: String, introduction: String?, profilImage: String?) {
         self.nickname = nickname
         self.email = email
         self.introduction = introduction
@@ -78,29 +78,38 @@ public struct UserVO : Codable {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         nickname = try values.decodeIfPresent(String.self, forKey: .nickname)
-        email = try values.decodeIfPresent(String.self, forKey: .email)
+        email = try values.decode(String.self, forKey: .email)
         introduction = try values.decodeIfPresent(String.self, forKey: .introduction)
         profilImage = try values.decodeIfPresent(String.self, forKey: .profilImage)
     }
 }
 
-public struct PatchUserVO : Codable {
+public struct PatchUserVO  {
     let nickname : String?
     let introduction : String?
-    let profilImage : String?
+    let profilImageURL : String?
     let categoryIds : [Int]?
     
     enum CodingKeys : String, CodingKey {
         case nickname
         case introduction
-        case profilImage
+        case profilImageURL = "profileImage"
         case categoryIds
     }
     
     public init(nickname: String?, introduction: String?, profilImage: String?, categoryIds: [Int]?) {
         self.nickname = nickname
         self.introduction = introduction
-        self.profilImage = profilImage
+        self.profilImageURL = profilImage
         self.categoryIds = categoryIds
     }
 }
+
+public struct ReAccessToken : Codable {
+    let accessToken : String
+    
+    enum CodingKeys : String, CodingKey {
+        case accessToken
+    }
+}
+

--- a/MyKkumi/MyKkumi/Domain/VO/PostVO.swift
+++ b/MyKkumi/MyKkumi/Domain/VO/PostVO.swift
@@ -62,7 +62,7 @@ public struct Writer: Codable {
     
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        profileImage = try values.decodeIfPresent(String.self, forKey: .profileImage)!
-        nickname = try values.decodeIfPresent(String.self, forKey: .nickname)!
+        profileImage = try values.decodeIfPresent(String.self, forKey: .profileImage) ?? "nullValue"
+        nickname = try values.decodeIfPresent(String.self, forKey: .nickname) ?? "nullValue"
     }
 }

--- a/MyKkumi/MyKkumi/Presentation/Auth/AuthViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Auth/AuthViewModel.swift
@@ -44,7 +44,6 @@ class AuthViewModel : AuthViewModelProtocol {
         let appleSignin = self.appleUserData
             .flatMap {authorizationCode in
                 let appleAuth = AppleAuth(authorizationCode: authorizationCode)
-                print(appleAuth)
                 return authUsecase.signinApple(appleAuth)
             }
             .share()

--- a/MyKkumi/MyKkumi/Presentation/Auth/MakeProfileViewController.swift
+++ b/MyKkumi/MyKkumi/Presentation/Auth/MakeProfileViewController.swift
@@ -23,13 +23,13 @@ class MakeProfileViewController : BaseViewController<MakeProfileViewModelProtoco
     
     public override func setupHierarchy() {
         view.addSubview(mainStack)
-        mainStack.addSubview(profileImage)
-        mainStack.addSubview(nickNameStack)
-        mainStack.addSubview(completeButton)
+        mainStack.addArrangedSubview(profileImage)
+        mainStack.addArrangedSubview(nickNameStack)
+        mainStack.addArrangedSubview(completeButton)
         
-        nickNameStack.addSubview(nickNameInfoButton)
-        nickNameStack.addSubview(nickNameLabel)
-        nickNameStack.addSubview(nickNameTextField)
+        nickNameStack.addArrangedSubview(nickNameInfoButton)
+        nickNameStack.addArrangedSubview(nickNameLabel)
+        nickNameStack.addArrangedSubview(nickNameTextField)
     }
     
     public override func setupDelegate() {
@@ -148,7 +148,7 @@ class MakeProfileViewController : BaseViewController<MakeProfileViewModelProtoco
         NSLayoutConstraint.activate([
             nickNameInfoButton.widthAnchor.constraint(equalTo: nickNameLabel.heightAnchor),
             nickNameInfoButton.heightAnchor.constraint(equalTo: nickNameLabel.heightAnchor),
-            nickNameInfoButton.leadingAnchor.constraint(equalTo: nickNameStack.leadingAnchor)
+            nickNameInfoButton.leadingAnchor.constraint(equalTo: nickNameStack.leadingAnchor),
         ])
         
         //nickNameLabel

--- a/MyKkumi/MyKkumi/Presentation/CommonUI/CollectionView/Post/SelectedImageCell.swift
+++ b/MyKkumi/MyKkumi/Presentation/CommonUI/CollectionView/Post/SelectedImageCell.swift
@@ -1,0 +1,67 @@
+//
+//  SelectedImageCell.swift
+//  MyKkumi
+//
+//  Created by 최재혁 on 7/31/24.
+//
+
+import UIKit
+
+open class SelectedImageCell : UICollectionViewCell {
+    public static let cellID = "SelectedImageCell"
+    var imageView : UIImageView = UIImageView(frame: .zero)
+    
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        initAtrribute()
+        initUI()
+    }
+    
+    private func initAtrribute() {
+        
+    }
+    
+    private func initUI() {
+        contentView.addSubview(imageView)
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+    
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+open class AddImageCell : UICollectionViewCell {
+    public static let cellID = "AddImageCell"
+    var addImageButton : UIButton = UIButton()
+    
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        initAtrribute()
+        initUI()
+    }
+    
+    private func initAtrribute() {
+        addImageButton.translatesAutoresizingMaskIntoConstraints = false
+        addImageButton.setBackgroundImage(UIImage(named: "chat"), for: .normal)
+    }
+    
+    private func initUI() {
+        contentView.addSubview(addImageButton)
+        NSLayoutConstraint.activate([
+            addImageButton.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            addImageButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            addImageButton.topAnchor.constraint(equalTo: contentView.topAnchor),
+            addImageButton.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+    
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/MyKkumi/MyKkumi/Presentation/CommonUI/CollectionView/Post/SelectedImageCell.swift
+++ b/MyKkumi/MyKkumi/Presentation/CommonUI/CollectionView/Post/SelectedImageCell.swift
@@ -6,10 +6,11 @@
 //
 
 import UIKit
+import RxSwift
 
 open class SelectedImageCell : UICollectionViewCell {
     public static let cellID = "SelectedImageCell"
-    var imageView : UIImageView = UIImageView(frame: .zero)
+    var imageView : UIImageView = UIImageView()
     
     override public init(frame: CGRect) {
         super.init(frame: frame)
@@ -18,7 +19,7 @@ open class SelectedImageCell : UICollectionViewCell {
     }
     
     private func initAtrribute() {
-        
+        imageView.translatesAutoresizingMaskIntoConstraints = false
     }
     
     private func initUI() {
@@ -38,12 +39,22 @@ open class SelectedImageCell : UICollectionViewCell {
 
 open class AddImageCell : UICollectionViewCell {
     public static let cellID = "AddImageCell"
+    var disposedBag = DisposeBag()
+    var viewModel : AddImageViewModelProtocol!
     var addImageButton : UIButton = UIButton()
     
     override public init(frame: CGRect) {
         super.init(frame: frame)
         initAtrribute()
         initUI()
+    }
+    
+    public func setBind(viewModel : AddImageViewModelProtocol) {
+        self.viewModel = viewModel
+        
+        addImageButton.rx.tap
+            .bind(to: viewModel.addButtonTap)
+            .disposed(by: disposedBag)
     }
     
     private func initAtrribute() {

--- a/MyKkumi/MyKkumi/Presentation/Home/HomeViewController.swift
+++ b/MyKkumi/MyKkumi/Presentation/Home/HomeViewController.swift
@@ -75,6 +75,7 @@ class HomeViewController: BaseViewController<HomeViewModelProtocol> {
         self.viewModel.shouldPushUploadPostView
             .drive(onNext : {[weak self] _ in
                 let makePostVC = MakePostViewController()
+                makePostVC.setupBind(viewModel: MakePostViewModel())
                 self?.navigationController?.pushViewController(makePostVC, animated: true)
             })
             .disposed(by: disposeBag)
@@ -270,7 +271,6 @@ extension HomeViewController : UITableViewDelegate, UITableViewDataSource {
             return cell
         } else {
             let cell = tableView.dequeueReusableCell(withIdentifier: PostTableCell.cellID, for: indexPath) as! PostTableCell
-            
             cell.bind(viewModel: viewModel.postViewModels.value[indexPath.row])
             return cell
         }

--- a/MyKkumi/MyKkumi/Presentation/Home/HomeViewController.swift
+++ b/MyKkumi/MyKkumi/Presentation/Home/HomeViewController.swift
@@ -76,6 +76,7 @@ class HomeViewController: BaseViewController<HomeViewModelProtocol> {
             .drive(onNext : {[weak self] _ in
                 let makePostVC = MakePostViewController()
                 makePostVC.setupBind(viewModel: MakePostViewModel())
+                makePostVC.hidesBottomBarWhenPushed  = true
                 self?.navigationController?.pushViewController(makePostVC, animated: true)
             })
             .disposed(by: disposeBag)

--- a/MyKkumi/MyKkumi/Presentation/Home/HomeViewController.swift
+++ b/MyKkumi/MyKkumi/Presentation/Home/HomeViewController.swift
@@ -72,6 +72,12 @@ class HomeViewController: BaseViewController<HomeViewModelProtocol> {
             .bind(to: viewModel.uploadPostButtonTap)
             .disposed(by: disposeBag)
         
+        self.viewModel.shouldPushUploadPostView
+            .drive(onNext : {[weak self] _ in
+                let makePostVC = MakePostViewController()
+                self?.navigationController?.pushViewController(makePostVC, animated: true)
+            })
+            .disposed(by: disposeBag)
     }
     
     public override func setupDelegate() {

--- a/MyKkumi/MyKkumi/Presentation/Home/HomeViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Home/HomeViewModel.swift
@@ -35,11 +35,14 @@ public class HomeViewModel : HomeViewModelProtocol {
     private let disposeBag = DisposeBag()
     private let bannerUsecase : BannerUsecase
     private let postUsecase : PostUsecase
+    private let authUsecase : AuthUsecase
     private let bannerDetailViewModel : BannerCellViewModelProtocol = BannerCellViewModel()
     
-    public init(bannerUsecase : BannerUsecase = DependencyInjector.shared.resolve(BannerUsecase.self), postUsecase : PostUsecase = DependencyInjector.shared.resolve(PostUsecase.self)) {
+    public init(bannerUsecase : BannerUsecase = DependencyInjector.shared.resolve(BannerUsecase.self), postUsecase : PostUsecase = DependencyInjector.shared.resolve(PostUsecase.self),
+                authUsecase : AuthUsecase = DependencyInjector.shared.resolve(AuthUsecase.self)) {
         self.bannerUsecase = bannerUsecase
         self.postUsecase = postUsecase
+        self.authUsecase = authUsecase
         self.viewdidload = PublishSubject<Void>()
         self.postTap = PublishSubject<Int64>()
         self.uploadPostButtonTap = PublishSubject<Void>()
@@ -55,6 +58,14 @@ public class HomeViewModel : HomeViewModelProtocol {
                 return bannerUsecase.getBanners()
             }
             .share()
+        
+        self.viewdidload
+            .subscribe(onNext: {
+                if KeychainHelper.shared.load(key: "refreshToken") != nil {
+                    authUsecase.refreshToken()
+                }
+            })
+            .disposed(by: disposeBag)
         
         self.bannerDataOutput = allBannerResult
             .compactMap { $0.successValue()?.banners}

--- a/MyKkumi/MyKkumi/Presentation/Home/HomeViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Home/HomeViewModel.swift
@@ -101,13 +101,24 @@ public class HomeViewModel : HomeViewModelProtocol {
             .map{_ in Void()}
             .asSignal(onErrorSignalWith: .empty())
         
-        self.uploadPostButtonTap
-            .subscribe(onNext: {
-                NotificationCenter.default.post(name : .showAuth, object : nil)
-            })
-            .disposed(by: disposeBag)
+        let isLogined = self.uploadPostButtonTap
+            .flatMap{_ -> Observable<Bool> in
+                if KeychainHelper.shared.load(service: "accessToken") == nil {
+                    NotificationCenter.default.post(name : .showAuth, object: nil)
+                    return Observable.just(false)
+                }
+                return Observable.just(true)
+            }
         
-        self.shouldPushUploadPostView = self.uploadPostButtonTap
+//        self.uploadPostButtonTap
+//            .subscribe(onNext: {
+//                NotificationCenter.default.post(name : .showAuth, object : nil)
+//            })
+//            .disposed(by: disposeBag)
+        
+        self.shouldPushUploadPostView = isLogined
+            .filter{$0}
+            .map{_ in ()}
             .asDriver(onErrorJustReturn: ())
         
         initSuccessPost

--- a/MyKkumi/MyKkumi/Presentation/Home/HomeViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Home/HomeViewModel.swift
@@ -102,24 +102,24 @@ public class HomeViewModel : HomeViewModelProtocol {
             .asSignal(onErrorSignalWith: .empty())
         
         let isLogined = self.uploadPostButtonTap
-            .flatMap{_ -> Observable<Bool> in
+            .flatMap{_ -> Single<Bool> in
                 if KeychainHelper.shared.load(service: "accessToken") == nil {
                     NotificationCenter.default.post(name : .showAuth, object: nil)
-                    return Observable.just(false)
+                    return .just(false)
                 }
-                return Observable.just(true)
+                return .just(true)
             }
         
-//        self.uploadPostButtonTap
-//            .subscribe(onNext: {
-//                NotificationCenter.default.post(name : .showAuth, object : nil)
-//            })
-//            .disposed(by: disposeBag)
+        self.uploadPostButtonTap
+            .subscribe(onNext: {
+                if KeychainHelper.shared.load(service: "accessToken") == nil {
+                    NotificationCenter.default.post(name : .showAuth, object: nil)
+                }
+            })
+            .disposed(by: disposeBag)
         
-        self.shouldPushUploadPostView = isLogined
-            .filter{$0}
-            .map{_ in ()}
-            .asDriver(onErrorJustReturn: ())
+        self.shouldPushUploadPostView = self.uploadPostButtonTap
+            .asDriver(onErrorDriveWith: .empty())
         
         initSuccessPost
             .subscribe(onNext: {[weak self] result in
@@ -143,6 +143,9 @@ public class HomeViewModel : HomeViewModelProtocol {
                 self.postViewModels.accept(tmpPostViewModels)
             })
             .disposed(by: disposeBag)
+        
+        //MARK: Post Tap
+        
     }
     
     public var viewdidload: PublishSubject<Void>

--- a/MyKkumi/MyKkumi/Presentation/Post/AddImageViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/AddImageViewModel.swift
@@ -1,0 +1,22 @@
+//
+//  AddImageViewModel.swift
+//  MyKkumi
+//
+//  Created by 최재혁 on 7/31/24.
+//
+
+import Foundation
+import RxSwift
+
+public protocol AddImageViewModelProtocol {
+    var addButtonTap : PublishSubject<Void> { get }
+}
+
+public class AddImageViewModel : AddImageViewModelProtocol {
+    
+    public init() {
+        self.addButtonTap = PublishSubject<Void>()
+    }
+    
+    public var addButtonTap: PublishSubject<Void>
+}

--- a/MyKkumi/MyKkumi/Presentation/Post/MakePostViewController.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/MakePostViewController.swift
@@ -38,7 +38,7 @@ class MakePostViewController : BaseViewController<MakePostViewModelProtocol> {
     }
     
     public override func setupBind(viewModel: MakePostViewModelProtocol) {
-        
+        self.viewModel = viewModel
     }
     
     override func setupLayout() {
@@ -70,6 +70,7 @@ class MakePostViewController : BaseViewController<MakePostViewModelProtocol> {
             buttonStack.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor, constant: -12),
         ])
         
+        
         //contentTextField
         NSLayoutConstraint.activate([
             contentTextFiled.topAnchor.constraint(equalTo: buttonStack.bottomAnchor, constant: 12),
@@ -83,6 +84,8 @@ class MakePostViewController : BaseViewController<MakePostViewModelProtocol> {
             AIContentButton.trailingAnchor.constraint(equalTo: contentTextFiled.trailingAnchor, constant: -8),
             AIContentButton.bottomAnchor.constraint(equalTo: contentTextFiled.bottomAnchor, constant: -8)
         ])
+        
+        
     }
     
     private var mainStack : UIStackView = {
@@ -101,8 +104,10 @@ class MakePostViewController : BaseViewController<MakePostViewModelProtocol> {
     }()
     
     private var imageCollectionView : UICollectionView = {
-        let collectionView = UICollectionView()
+        let collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: PostImageCollectionViewFlowLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.register(SelectedImageCell.self, forCellWithReuseIdentifier: SelectedImageCell.cellID)
+        collectionView.register(AddImageCell.self, forCellWithReuseIdentifier: AddImageCell.cellID)
         return collectionView
     }()
     
@@ -147,11 +152,31 @@ class MakePostViewController : BaseViewController<MakePostViewModelProtocol> {
 
 extension MakePostViewController : UICollectionViewDelegate, UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        <#code#>
+        let imageCount = viewModel.selectedImageRelay.value.count
+        if imageCount == 10 {
+            return 10
+        } else {
+            return imageCount + 1
+        }
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        <#code#>
+        let imageCount = viewModel.selectedImageRelay.value.count
+        if imageCount == 10 {
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SelectedImageCell.cellID, for: indexPath) as! SelectedImageCell
+            cell.imageView.image = viewModel.selectedImageRelay.value[indexPath.row]
+            return cell
+        } else {
+            if(indexPath.row == imageCount) {
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: AddImageCell.cellID, for: indexPath) as! AddImageCell
+                return cell
+                
+            } else {
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SelectedImageCell.cellID, for: indexPath) as! SelectedImageCell
+                cell.imageView.image = viewModel.selectedImageRelay.value[indexPath.row]
+                return cell
+            }
+        }
     }
     
     

--- a/MyKkumi/MyKkumi/Presentation/Post/MakePostViewController.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/MakePostViewController.swift
@@ -1,0 +1,162 @@
+//
+//  MakePostViewController.swift
+//  MyKkumi
+//
+//  Created by 최재혁 on 7/31/24.
+//
+
+import Foundation
+import UIKit
+import RxSwift
+import RxCocoa
+
+class MakePostViewController : BaseViewController<MakePostViewModelProtocol> {
+    var viewModel : MakePostViewModelProtocol!
+    
+    override init() {
+        super.init()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func setupHierarchy() {
+        view.addSubview(mainStack)
+        mainStack.addSubview(imageCollectionView)
+        mainStack.addSubview(selectedImageView)
+        mainStack.addSubview(buttonStack)
+        buttonStack.addSubview(addPinButton)
+        buttonStack.addSubview(autoPinAddButton)
+        mainStack.addSubview(contentTextFiled)
+        mainStack.addSubview(AIContentButton)
+    }
+    
+    override func setupDelegate() {
+        imageCollectionView.delegate = self
+        imageCollectionView.dataSource = self
+    }
+    
+    public override func setupBind(viewModel: MakePostViewModelProtocol) {
+        
+    }
+    
+    override func setupLayout() {
+        //MainStack
+        NSLayoutConstraint.activate([
+            mainStack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            mainStack.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            mainStack.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            mainStack.leadingAnchor.constraint(equalTo: view.leadingAnchor)
+        ])
+        
+        //collectionView
+        NSLayoutConstraint.activate([
+            imageCollectionView.topAnchor.constraint(equalTo: mainStack.topAnchor),
+            imageCollectionView.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor, constant: -12),
+            imageCollectionView.leadingAnchor.constraint(equalTo: mainStack.leadingAnchor, constant: 12)
+        ])
+        
+        //selectedImage
+        NSLayoutConstraint.activate([
+            selectedImageView.topAnchor.constraint(equalTo: imageCollectionView.bottomAnchor, constant: 15),
+            selectedImageView.leadingAnchor.constraint(equalTo: mainStack.leadingAnchor),
+            selectedImageView.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor),
+            selectedImageView.bottomAnchor.constraint(equalTo: buttonStack.topAnchor, constant: -12)
+        ])
+        
+        //ButtonStack
+        NSLayoutConstraint.activate([
+            buttonStack.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor, constant: -12),
+        ])
+        
+        //contentTextField
+        NSLayoutConstraint.activate([
+            contentTextFiled.topAnchor.constraint(equalTo: buttonStack.bottomAnchor, constant: 12),
+            contentTextFiled.trailingAnchor.constraint(equalTo: mainStack.trailingAnchor),
+            contentTextFiled.bottomAnchor.constraint(equalTo: mainStack.bottomAnchor),
+            contentTextFiled.leadingAnchor.constraint(equalTo: mainStack.leadingAnchor)
+        ])
+        
+        //AIContentBUtton
+        NSLayoutConstraint.activate([
+            AIContentButton.trailingAnchor.constraint(equalTo: contentTextFiled.trailingAnchor, constant: -8),
+            AIContentButton.bottomAnchor.constraint(equalTo: contentTextFiled.bottomAnchor, constant: -8)
+        ])
+    }
+    
+    private var mainStack : UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .vertical
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+    
+    private var buttonStack : UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 5
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+    
+    private var imageCollectionView : UICollectionView = {
+        let collectionView = UICollectionView()
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        return collectionView
+    }()
+    
+    private var selectedImageView : UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private var addPinButton : UIButton = {
+        let button = UIButton()
+        button.setTitle("핀 추가", for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private var autoPinAddButton : UIButton = {
+        let button = UIButton()
+        button.setTitle("핀 자동 생성", for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private var contentTextFiled : UITextView = {
+        let textView = UITextView()
+        textView.keyboardType = .default
+        textView.returnKeyType = .done
+        textView.isUserInteractionEnabled = true
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.layer.borderWidth = 1.0
+        textView.layer.borderColor = UIColor.black.cgColor
+        return textView
+    }()
+    
+    private var AIContentButton : UIButton = {
+        let button = UIButton()
+        button.setTitle("AI 글 작성", for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+}
+
+extension MakePostViewController : UICollectionViewDelegate, UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        <#code#>
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        <#code#>
+    }
+    
+    
+}
+
+extension MakePostViewController : UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    
+}

--- a/MyKkumi/MyKkumi/Presentation/Post/MakePostViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/MakePostViewModel.swift
@@ -8,26 +8,115 @@
 import Foundation
 import RxCocoa
 import RxSwift
+import Photos
+import AVFoundation
 
 public protocol MakePostViewModelInput {
-    
+    var cameraTap : PublishSubject<Void> { get }
+    var libraryTap : PublishSubject<Void> { get }
 }
 
 public protocol MakePostViewModelOutput {
-    
+    var sholudPushSelectAlert : Driver<Void> { get }
+    var sholudPushImagePicker : Driver<Bool> { get }
+    var sholudPushCamera : Driver<Bool> { get }
 }
 
-public protocol MakePostViewModelProtocol {
+public protocol MakePostViewModelProtocol : MakePostViewModelOutput,  MakePostViewModelInput{
     var selectedImageRelay : BehaviorRelay<[UIImage]>{ get }
+    var selectedImageViewModels : BehaviorRelay<[SelectedImageViewModelProtocol]> { get }
+    var deliverAddImageViewModel : BehaviorRelay<AddImageViewModelProtocol>{ get }
 }
 
 public class MakePostViewModel : MakePostViewModelProtocol {
     
     private let disposeBag = DisposeBag()
+    private let addImageViewModel = AddImageViewModel()
     
     public init() {
         self.selectedImageRelay = BehaviorRelay<[UIImage]>(value: [])
+        self.selectedImageViewModels = BehaviorRelay<[SelectedImageViewModelProtocol]>(value: [])
+        self.deliverAddImageViewModel = BehaviorRelay<AddImageViewModelProtocol>(value: addImageViewModel)
+        self.cameraTap = PublishSubject<Void>()
+        self.libraryTap = PublishSubject<Void>()
+        
+        self.sholudPushSelectAlert = self.addImageViewModel.addButtonTap
+            .asDriver(onErrorDriveWith: .empty())
+        
+        let libraryAuth = self.libraryTap
+            .compactMap {_ -> Bool? in
+                let status = PHPhotoLibrary.authorizationStatus()
+                switch status {
+                case .authorized :
+                    return true
+                case .denied, .restricted :
+                    return false
+                case .notDetermined :
+                    var flag = false
+                    PHPhotoLibrary.requestAuthorization { newStatus in
+                        if newStatus == .authorized {
+                            flag = true
+                        } else {
+                            flag = false
+                        }
+                    }
+                    return flag
+                case .limited :
+                    return true
+                @unknown default :
+                    return false
+                }
+            }
+        
+        self.sholudPushImagePicker = libraryAuth
+            .asDriver(onErrorDriveWith: .empty())
+        
+        let cameraAuth = self.cameraTap
+            .compactMap{_ -> Bool? in
+                let status = AVCaptureDevice.authorizationStatus(for: .video)
+                switch status {
+                case .authorized :
+                    return true
+                case .denied, .restricted :
+                    return false
+                case .notDetermined :
+                    var flag = false
+                    AVCaptureDevice.requestAccess(for: .video) { granted in
+                        if granted {
+                            flag = true
+                        } else {
+                            flag = false
+                        }
+                    }
+                    return flag
+                @unknown default :
+                    return false
+                }
+            }
+        
+        self.sholudPushCamera = cameraAuth
+            .asDriver(onErrorDriveWith: .empty())
+        
+        self.selectedImageRelay
+            .subscribe(onNext: {[weak self] images in
+                guard let self = self else {return}
+                var tmpViewModel : [SelectedImageViewModelProtocol] = []
+                images.forEach { image in
+                    tmpViewModel.append(SelectedImageViewModel())
+                }
+                self.selectedImageViewModels.accept(tmpViewModel)
+            })
+            .disposed(by: disposeBag)
     }
     
+    public var sholudPushSelectAlert: Driver<Void>
+    public var sholudPushCamera: Driver<Bool>
+    public var sholudPushImagePicker: Driver<Bool>
+    
+    public var cameraTap: PublishSubject<Void>
+    public var libraryTap: PublishSubject<Void>
+    
     public var selectedImageRelay: BehaviorRelay<[UIImage]>
+    public var selectedImageViewModels: BehaviorRelay<[any SelectedImageViewModelProtocol]>
+    public var deliverAddImageViewModel: BehaviorRelay<any AddImageViewModelProtocol>
 }

--- a/MyKkumi/MyKkumi/Presentation/Post/MakePostViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/MakePostViewModel.swift
@@ -1,0 +1,31 @@
+//
+//  MakePostViewModel.swift
+//  MyKkumi
+//
+//  Created by 최재혁 on 7/31/24.
+//
+
+import Foundation
+import RxCocoa
+import RxSwift
+
+public protocol MakePostViewModelInput {
+    
+}
+
+public protocol MakePostViewModelOutput {
+    
+}
+
+public protocol MakePostViewModelProtocol {
+    
+}
+
+public class MakePostViewModel : MakePostViewModelProtocol {
+    
+    private let disposeBag = DisposeBag()
+    
+    public init() {
+        
+    }
+}

--- a/MyKkumi/MyKkumi/Presentation/Post/MakePostViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/MakePostViewModel.swift
@@ -18,7 +18,7 @@ public protocol MakePostViewModelOutput {
 }
 
 public protocol MakePostViewModelProtocol {
-    
+    var selectedImageRelay : BehaviorRelay<[UIImage]>{ get }
 }
 
 public class MakePostViewModel : MakePostViewModelProtocol {
@@ -26,6 +26,8 @@ public class MakePostViewModel : MakePostViewModelProtocol {
     private let disposeBag = DisposeBag()
     
     public init() {
-        
+        self.selectedImageRelay = BehaviorRelay<[UIImage]>(value: [])
     }
+    
+    public var selectedImageRelay: BehaviorRelay<[UIImage]>
 }

--- a/MyKkumi/MyKkumi/Presentation/Post/SelectedImageViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/SelectedImageViewModel.swift
@@ -1,0 +1,33 @@
+//
+//  MakePostViewModel.swift
+//  MyKkumi
+//
+//  Created by 최재혁 on 7/31/24.
+//
+
+import Foundation
+import RxCocoa
+import RxSwift
+
+public protocol SelectedImageViewModelInput {
+    
+}
+
+public protocol SelectedImageViewModelOutput {
+    
+}
+
+public protocol SelectedImageViewModelProtocol : SelectedImageViewModelInput, SelectedImageViewModelOutput{
+    
+}
+
+public class SelectedImageViewModel : SelectedImageViewModelProtocol {
+    
+    private let disposeBag = DisposeBag()
+    
+    public init() {
+        self.selectedImageRelay = BehaviorRelay<[UIImage]>(value: [])
+    }
+    
+    public var selectedImageRelay: BehaviorRelay<[UIImage]>
+}

--- a/MyKkumi/MyKkumi/Resources/Info.plist
+++ b/MyKkumi/MyKkumi/Resources/Info.plist
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSCameraUsageDescription</key>
-	<string>포스트 등록, 프로필 설정을 목적으로 마이꾸미의 회원님의 카메라에 대한 엑세스 권한을 요청합니다.</string>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>포스트 등록, 프로필 설정을 목적으로 마이꾸미의 회원님의 사진 보관함에 대한 엑세스 권한을 요청합니다.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -16,6 +12,7 @@
 				<string>kakao55d592206f0b04c3ea9856a84a02a293</string>
 			</array>
 		</dict>
+		<dict/>
 	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>


### PR DESCRIPTION
## 구현내용
### ㅇ 1. keychain helper 수정
- 필요 없는 파라미터 삭제
- 앱 실행시 자동 로그인, 로그인시 키체인에 값 등록

### ㅇ 2. makePostView 생성
- 해당부분의 각 ImageCell에 대한 viewmodel 생성 필요
- 시작시 카마라 또는 갤러리 들어갈 수 있도록 변경 필요
- 이미지 다중선택시 load하는 부분이 비동기적으로 이루어지는 부분을 동기적으로 변환(DispatchGroup사용)

### ㅇ 3. 앱 실행시 토큰 refresh -> HomeViewController didLoad시 refresh
- 해당 부분 적용을 위해 refresh 하는 service와 datasource를 생성
- viewDidLoad시 자동으로 호출하도록 Viewmodel과 연결

## 고민사항
### ㅇ 1. interCepter부분의 코드에 문제가 없는지 고민입니다.
- 불필요한 코드나 필요한 코드가 제외되어 있는 부분이 있을지 고민입니다.

### ㅇ 2. 동기화가 정상적으로 이루어졌는지 의문입니다.
- mainThread에서 DispatchQueue사용시 주의해야 할 점을 만족하였는지 의문입니다.
