### PR TITLE
[MERGE] collectionView에서의 cell삭제와 선택에 따른 viewModel 연결 변경

### DIFF
--- a/MyKkumi/MyKkumi.xcodeproj/project.pbxproj
+++ b/MyKkumi/MyKkumi.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		D230F93C2C1D714E00C43797 /* MyKkumiTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D230F93B2C1D714E00C43797 /* MyKkumiTests.swift */; };
 		D230F9462C1D714E00C43797 /* MyKkumiUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D230F9452C1D714E00C43797 /* MyKkumiUITests.swift */; };
 		D230F9482C1D714E00C43797 /* MyKkumiUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D230F9472C1D714E00C43797 /* MyKkumiUITestsLaunchTests.swift */; };
+		D2672BCC2C609271005B23A4 /* SelectedImageFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2672BCB2C609271005B23A4 /* SelectedImageFlowLayout.swift */; };
 		D2828C3B2C53A5100036DFDD /* RootWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2828C3A2C53A5100036DFDD /* RootWindow.swift */; };
 		D28346D72C3575ED0048CB2E /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28346D62C3575ED0048CB2E /* UIViewController+Rx.swift */; };
 		D28346F72C37F6230048CB2E /* HomeBannerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28346F62C37F6230048CB2E /* HomeBannerCell.swift */; };
@@ -145,6 +146,7 @@
 		D230F9412C1D714E00C43797 /* MyKkumiUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MyKkumiUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D230F9452C1D714E00C43797 /* MyKkumiUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyKkumiUITests.swift; sourceTree = "<group>"; };
 		D230F9472C1D714E00C43797 /* MyKkumiUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyKkumiUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		D2672BCB2C609271005B23A4 /* SelectedImageFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedImageFlowLayout.swift; sourceTree = "<group>"; };
 		D2828C392C4EEABB0036DFDD /* MyKkumi.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MyKkumi.entitlements; sourceTree = "<group>"; };
 		D2828C3A2C53A5100036DFDD /* RootWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootWindow.swift; sourceTree = "<group>"; };
 		D28346D62C3575ED0048CB2E /* UIViewController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Rx.swift"; sourceTree = "<group>"; };
@@ -578,6 +580,7 @@
 				D2ABCE2C2C33C53A0035F7A1 /* PostImageCollectionViewCell.swift */,
 				D2ABCE302C33C64C0035F7A1 /* PostImageCollectionViewFlowLayout.swift */,
 				D2C79F2D2C5A2D5000E41D8C /* SelectedImageCell.swift */,
+				D2672BCB2C609271005B23A4 /* SelectedImageFlowLayout.swift */,
 			);
 			path = Post;
 			sourceTree = "<group>";
@@ -1019,6 +1022,7 @@
 				D2ABCE3D2C3434F00035F7A1 /* PostUsecase.swift in Sources */,
 				D2ABCE1E2C2EAB5D0035F7A1 /* BannerInfoViewController.swift in Sources */,
 				D2ED95402C46AF0A004DA169 /* AuthRepository.swift in Sources */,
+				D2672BCC2C609271005B23A4 /* SelectedImageFlowLayout.swift in Sources */,
 				D2ABCE112C2D2E9F0035F7A1 /* BannerService.swift in Sources */,
 				D2ABCDED2C2AAEA10035F7A1 /* HomeViewModel.swift in Sources */,
 				D2E4595C2C1E383D00DB0756 /* BasicCommon.swift in Sources */,

--- a/MyKkumi/MyKkumi.xcodeproj/project.pbxproj
+++ b/MyKkumi/MyKkumi.xcodeproj/project.pbxproj
@@ -28,6 +28,10 @@
 		D230F9462C1D714E00C43797 /* MyKkumiUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D230F9452C1D714E00C43797 /* MyKkumiUITests.swift */; };
 		D230F9482C1D714E00C43797 /* MyKkumiUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D230F9472C1D714E00C43797 /* MyKkumiUITestsLaunchTests.swift */; };
 		D2672BCC2C609271005B23A4 /* SelectedImageFlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2672BCB2C609271005B23A4 /* SelectedImageFlowLayout.swift */; };
+		D2672BCE2C61F196005B23A4 /* WritePostVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2672BCD2C61F196005B23A4 /* WritePostVO.swift */; };
+		D2672BD02C62B3D8005B23A4 /* PinInfoPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2672BCF2C62B3D8005B23A4 /* PinInfoPresentationController.swift */; };
+		D2672BD22C62B64B005B23A4 /* PinInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2672BD12C62B64B005B23A4 /* PinInfoViewModel.swift */; };
+		D2672BD42C62B723005B23A4 /* PinInfoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2672BD32C62B723005B23A4 /* PinInfoViewController.swift */; };
 		D2828C3B2C53A5100036DFDD /* RootWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2828C3A2C53A5100036DFDD /* RootWindow.swift */; };
 		D28346D72C3575ED0048CB2E /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28346D62C3575ED0048CB2E /* UIViewController+Rx.swift */; };
 		D28346F72C37F6230048CB2E /* HomeBannerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D28346F62C37F6230048CB2E /* HomeBannerCell.swift */; };
@@ -147,6 +151,10 @@
 		D230F9452C1D714E00C43797 /* MyKkumiUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyKkumiUITests.swift; sourceTree = "<group>"; };
 		D230F9472C1D714E00C43797 /* MyKkumiUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyKkumiUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		D2672BCB2C609271005B23A4 /* SelectedImageFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedImageFlowLayout.swift; sourceTree = "<group>"; };
+		D2672BCD2C61F196005B23A4 /* WritePostVO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WritePostVO.swift; sourceTree = "<group>"; };
+		D2672BCF2C62B3D8005B23A4 /* PinInfoPresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinInfoPresentationController.swift; sourceTree = "<group>"; };
+		D2672BD12C62B64B005B23A4 /* PinInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinInfoViewModel.swift; sourceTree = "<group>"; };
+		D2672BD32C62B723005B23A4 /* PinInfoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinInfoViewController.swift; sourceTree = "<group>"; };
 		D2828C392C4EEABB0036DFDD /* MyKkumi.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MyKkumi.entitlements; sourceTree = "<group>"; };
 		D2828C3A2C53A5100036DFDD /* RootWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootWindow.swift; sourceTree = "<group>"; };
 		D28346D62C3575ED0048CB2E /* UIViewController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Rx.swift"; sourceTree = "<group>"; };
@@ -531,6 +539,7 @@
 				D2ABCE052C2D20110035F7A1 /* ErrorVO.swift */,
 				D2ABCE322C3424010035F7A1 /* PostVO.swift */,
 				D2ED953A2C46A80D004DA169 /* AuthVO.swift */,
+				D2672BCD2C61F196005B23A4 /* WritePostVO.swift */,
 			);
 			path = VO;
 			sourceTree = "<group>";
@@ -589,9 +598,12 @@
 			isa = PBXGroup;
 			children = (
 				D2C79F292C5A1A7600E41D8C /* MakePostViewController.swift */,
+				D2672BD32C62B723005B23A4 /* PinInfoViewController.swift */,
 				D2C79F2B2C5A1AB200E41D8C /* MakePostViewModel.swift */,
 				D2C79F2F2C5A6FB200E41D8C /* SelectedImageViewModel.swift */,
 				D2C79F312C5A70B700E41D8C /* AddImageViewModel.swift */,
+				D2672BCF2C62B3D8005B23A4 /* PinInfoPresentationController.swift */,
+				D2672BD12C62B64B005B23A4 /* PinInfoViewModel.swift */,
 			);
 			path = Post;
 			sourceTree = "<group>";
@@ -960,6 +972,7 @@
 				D2ED95312C440F3C004DA169 /* CollectCategoryViewController.swift in Sources */,
 				D230F9292C1D714C00C43797 /* ViewController.swift in Sources */,
 				D2ED953D2C46A907004DA169 /* AuthService.swift in Sources */,
+				D2672BCE2C61F196005B23A4 /* WritePostVO.swift in Sources */,
 				D28347042C3BB1D50048CB2E /* BannerCellViewModel.swift in Sources */,
 				D2ED95352C44C7F1004DA169 /* MakeProfileViewController.swift in Sources */,
 				D2ABCE3B2C3434140035F7A1 /* PostRespository.swift in Sources */,
@@ -1007,6 +1020,7 @@
 				D2ABCDDC2C2A6E780035F7A1 /* DependencyInjector.swift in Sources */,
 				D21030632C2177E90059CACA /* BasicNetwork.swift in Sources */,
 				D2ED95512C4E1BB2004DA169 /* CategoryCollectionViewCell.swift in Sources */,
+				D2672BD42C62B723005B23A4 /* PinInfoViewController.swift in Sources */,
 				D230F9272C1D714C00C43797 /* SceneDelegate.swift in Sources */,
 				D2ABCE1A2C2D4F590035F7A1 /* DomainAssembly.swift in Sources */,
 				D2ABCDE52C2A9CED0035F7A1 /* HomeViewController.swift in Sources */,
@@ -1016,6 +1030,7 @@
 				D2ED95332C440F4D004DA169 /* CollectCategoryViewModel.swift in Sources */,
 				D2ABCE062C2D20110035F7A1 /* ErrorVO.swift in Sources */,
 				D2ABCE222C3271B60035F7A1 /* BannerInfoViewModel.swift in Sources */,
+				D2672BD22C62B64B005B23A4 /* PinInfoViewModel.swift in Sources */,
 				D28346D72C3575ED0048CB2E /* UIViewController+Rx.swift in Sources */,
 				D21030602C1FC1900059CACA /* HelloWorld.swift in Sources */,
 				D2ABCE012C2C01880035F7A1 /* BannerCollectionViewFlowLayout.swift in Sources */,
@@ -1036,6 +1051,7 @@
 				D2ABCE1C2C2D94EE0035F7A1 /* DetailBannerViewController.swift in Sources */,
 				D2ABCDD82C2A6AE10035F7A1 /* BasicAssembly.swift in Sources */,
 				D2ABCDD42C2A69D10035F7A1 /* BasicRepository.swift in Sources */,
+				D2672BD02C62B3D8005B23A4 /* PinInfoPresentationController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MyKkumi/MyKkumi/Domain/VO/WritePostVO.swift
+++ b/MyKkumi/MyKkumi/Domain/VO/WritePostVO.swift
@@ -1,0 +1,49 @@
+//
+//  WritePostVO.swift
+//  MyKkumi
+//
+//  Created by 최재혁 on 8/6/24.
+//
+
+import Foundation
+
+public struct WritePostVO : Codable {
+    let subCategoryId : Int
+    var content : String?
+    var images : [Image]
+}
+
+public struct Image : Codable {
+    let url : String
+    var pins : [Pin]
+}
+
+public struct Pin : Codable {
+    var positionX : Double
+    var positionY : Double
+    var productInfo : ProductInfo?
+    
+    public init(positionX: Double, positionY: Double, productInfo: ProductInfo? = nil) {
+        self.positionX = positionX
+        self.positionY = positionY
+        self.productInfo = productInfo
+    }
+}
+
+public struct ProductInfo : Codable {
+    var name : String
+    var url : String
+}
+
+public struct WritePostResponse : Codable {
+    let postId : Int
+    
+    enum CodingKeys : String, CodingKey {
+        case postId
+    }
+    
+    public init(from decoder : Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        postId =  try values.decode(Int.self , forKey: .postId)
+    }
+}

--- a/MyKkumi/MyKkumi/Presentation/CommonUI/CollectionView/Post/SelectedImageCell.swift
+++ b/MyKkumi/MyKkumi/Presentation/CommonUI/CollectionView/Post/SelectedImageCell.swift
@@ -10,7 +10,10 @@ import RxSwift
 
 open class SelectedImageCell : UICollectionViewCell {
     public static let cellID = "SelectedImageCell"
+    var disposeBag = DisposeBag()
     var imageView : UIImageView = UIImageView()
+    var deleteButton : UIButton = UIButton()
+    var viewModel : SelectedImageViewModelProtocol!
     
     override public init(frame: CGRect) {
         super.init(frame: frame)
@@ -20,15 +23,38 @@ open class SelectedImageCell : UICollectionViewCell {
     
     private func initAtrribute() {
         imageView.translatesAutoresizingMaskIntoConstraints = false
+        deleteButton.translatesAutoresizingMaskIntoConstraints = false
+        deleteButton.setTitle("X", for: .normal)
+        deleteButton.setTitleColor(.black, for: .normal)
+        deleteButton.backgroundColor = .red
+    }
+    
+    public func setBind(viewModel : SelectedImageViewModelProtocol) {
+        self.viewModel = viewModel
+        
+        imageView.rx.tapGesture
+            .map{_ in}
+            .bind(to: viewModel.imageTap)
+            .disposed(by: disposeBag)
+        
+        deleteButton.rx.tap
+            .bind(to: viewModel.deleteButtonTap)
+            .disposed(by: disposeBag)
     }
     
     private func initUI() {
         contentView.addSubview(imageView)
+        contentView.addSubview(deleteButton)
         NSLayoutConstraint.activate([
             imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
             imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
             imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
             imageView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            deleteButton.topAnchor.constraint(equalTo: imageView.topAnchor),
+            deleteButton.trailingAnchor.constraint(equalTo: imageView.trailingAnchor)
         ])
     }
     

--- a/MyKkumi/MyKkumi/Presentation/CommonUI/CollectionView/Post/SelectedImageCell.swift
+++ b/MyKkumi/MyKkumi/Presentation/CommonUI/CollectionView/Post/SelectedImageCell.swift
@@ -33,12 +33,26 @@ open class SelectedImageCell : UICollectionViewCell {
         self.viewModel = viewModel
         
         imageView.rx.tapGesture
-            .map{_ in}
+            .map{_ in viewModel.indexPathRow}
             .bind(to: viewModel.imageTap)
             .disposed(by: disposeBag)
         
         deleteButton.rx.tap
+            .map{_ in viewModel.indexPathRow}
             .bind(to: viewModel.deleteButtonTap)
+            .disposed(by: disposeBag)
+        
+        viewModel.selectedCell
+            .drive(onNext : {[weak self] _ in
+                self?.imageView.layer.borderWidth = 2.0
+                self?.imageView.layer.borderColor = UIColor.black.cgColor
+            })
+            .disposed(by: disposeBag)
+        
+        viewModel.unSelectedCell
+            .drive(onNext : {[weak self] _ in
+                self?.imageView.layer.borderWidth = 0.0
+            })
             .disposed(by: disposeBag)
     }
     

--- a/MyKkumi/MyKkumi/Presentation/CommonUI/CollectionView/Post/SelectedImageFlowLayout.swift
+++ b/MyKkumi/MyKkumi/Presentation/CommonUI/CollectionView/Post/SelectedImageFlowLayout.swift
@@ -1,0 +1,25 @@
+//
+//  PostImageCollectionViewFlowLayout.swift
+//  MyKkumi
+//
+//  Created by 최재혁 on 7/2/24.
+//
+
+import UIKit
+
+open class SelectedImageFlowLayout : UICollectionViewFlowLayout {
+    public override init() {
+        super.init()
+        initAttribute()
+    }
+    
+    private func initAttribute() {
+        scrollDirection = .horizontal
+        minimumLineSpacing = 5
+        minimumInteritemSpacing = 5
+    }
+    
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/MyKkumi/MyKkumi/Presentation/Post/MakePostViewController.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/MakePostViewController.swift
@@ -186,6 +186,23 @@ class MakePostViewController : BaseViewController<MakePostViewModelProtocol> {
                 }
             })
             .disposed(by: disposeBag)
+        
+        self.viewModel.deletePin
+            .drive(onNext: {[weak self] index in
+                guard let self = self else {return}
+                if viewModel.selectedImageIndex >= 0 {
+                    self.selectedImageAndPin.subviews.forEach{ subview in
+                        if let button = subview as? UIButton {
+                            if button.tag == index {
+                                button.removeFromSuperview()
+                            } else if button.tag > index {
+                                button.tag = button.tag - 1
+                            }
+                        }
+                    }
+                }
+            })
+            .disposed(by: disposeBag)
             
     }
     

--- a/MyKkumi/MyKkumi/Presentation/Post/MakePostViewController.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/MakePostViewController.swift
@@ -82,6 +82,14 @@ class MakePostViewController : BaseViewController<MakePostViewModelProtocol> {
                 }
             })
             .disposed(by: disposeBag)
+        
+        viewModel.deleteCellImage
+            .drive(onNext : {[weak self] result in
+                if result {
+                    self?.imageCollectionView.reloadData()
+                }
+            })
+            .disposed(by: disposeBag)
     }
     
     override func setupLayout() {
@@ -199,6 +207,7 @@ extension MakePostViewController : UICollectionViewDelegate, UICollectionViewDat
         if imageCount == 10 {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SelectedImageCell.cellID, for: indexPath) as! SelectedImageCell
             cell.imageView.image = viewModel.selectedImageRelay.value[indexPath.row]
+            cell.setBind(viewModel: viewModel.selectedImageViewModels.value[indexPath.row])
             return cell
         } else {
             if(indexPath.row == imageCount) {
@@ -208,6 +217,7 @@ extension MakePostViewController : UICollectionViewDelegate, UICollectionViewDat
             } else {
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SelectedImageCell.cellID, for: indexPath) as! SelectedImageCell
                 cell.imageView.image = viewModel.selectedImageRelay.value[indexPath.row]
+                cell.setBind(viewModel: viewModel.selectedImageViewModels.value[indexPath.row])
                 return cell
             }
         }

--- a/MyKkumi/MyKkumi/Presentation/Post/MakePostViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/MakePostViewModel.swift
@@ -16,38 +16,70 @@ public protocol MakePostViewModelInput {
     var libraryTap : PublishSubject<Void> { get }
     var deleteCellImageInput : PublishSubject<Int> { get }
     var deliverSelectedIndex : PublishSubject<Int> { get }
+    var addPinButtonTap : PublishSubject<Void> { get }
+    var pinTap : PublishSubject<Int> { get }
+    var deletePinButtonTap : PublishSubject<Int> { get }
+    var modifyPinOptionButtonTap : PublishSubject<Int> { get }
+    var modifyPinButtonTap : PublishSubject<[String : Any]> { get }
+    var pinDragFinish : BehaviorSubject<[String : Any]> { get }
+    var contentInput : PublishSubject<String?> { get }
 }
 
 public protocol MakePostViewModelOutput {
     var sholudPushSelectAlert : Driver<Void> { get }
     var sholudPushImagePicker : Driver<Bool> { get }
     var sholudPushCamera : Driver<Bool> { get }
+    var sholudPushModifyPinInfo : Driver<Int> { get }
     var deleteCellImage : Driver<Int> { get }
     var changeSelectedImage : Driver<Void> { get }
+    var addPin : Driver<Void> { get }
+    var deletePin : Driver<Void> { get }
+    var sholudPushPinOption : Driver<Int> { get }
+    var dismissModifyInfo : Driver<Void> { get }
 }
 
 public protocol MakePostViewModelProtocol : MakePostViewModelOutput,  MakePostViewModelInput{
     var selectedImageRelay : BehaviorRelay<[UIImage]>{ get }
     var selectedImageViewModels : BehaviorRelay<[SelectedImageViewModelProtocol]> { get }
     var deliverAddImageViewModel : BehaviorRelay<AddImageViewModelProtocol>{ get }
+    var deliverPinInfoViewModel : BehaviorRelay<PinInfoViewModelProtocol> { get }
     var selectedImageIndex : Int { get }
+    var pinsRelay : BehaviorRelay<[[Pin]]> { get }
+    var imageSize : BehaviorRelay<CGRect> { get }
+    var content : BehaviorRelay<String> { get }
 }
 
 public class MakePostViewModel : MakePostViewModelProtocol {
     
     private let disposeBag = DisposeBag()
     private let addImageViewModel = AddImageViewModel()
+    private let pinInfoViewModel = PinInfoViewModel(-1)
     public var selectedImageIndex: Int = -1
     
     public init() {
         self.selectedImageRelay = BehaviorRelay<[UIImage]>(value: [])
         self.selectedImageViewModels = BehaviorRelay<[SelectedImageViewModelProtocol]>(value: [])
         self.deliverAddImageViewModel = BehaviorRelay<AddImageViewModelProtocol>(value: addImageViewModel)
+        self.deliverPinInfoViewModel = BehaviorRelay<PinInfoViewModelProtocol>(value: pinInfoViewModel)
+        self.pinsRelay = BehaviorRelay<[[Pin]]>(value : [])
+        self.imageSize = BehaviorRelay<CGRect>(value: CGRect())
+        self.content = BehaviorRelay<String>(value: "")
+        
         self.cameraTap = PublishSubject<Void>()
         self.libraryTap = PublishSubject<Void>()
         self.deleteCellImageInput = PublishSubject<Int>()
         self.deliverSelectedIndex = PublishSubject<Int>()
+        self.addPinButtonTap = PublishSubject<Void>()
+        self.deletePinButtonTap = PublishSubject<Int>()
+        self.modifyPinOptionButtonTap = PublishSubject<Int>()
+        self.modifyPinButtonTap = PublishSubject<[String : Any]>()
+        self.pinTap = PublishSubject<Int>()
+        self.pinDragFinish = BehaviorSubject<[String : Any]>(value: ["pId" : -1,
+                                                                     "point" : CGPoint()
+                                                                    ])
+        self.contentInput = PublishSubject<String?>()
         
+        //MARK: cameraSubject
         self.sholudPushSelectAlert = self.addImageViewModel.addButtonTap
             .asDriver(onErrorDriveWith: .empty())
         
@@ -105,12 +137,107 @@ public class MakePostViewModel : MakePostViewModelProtocol {
         self.sholudPushCamera = cameraAuth
         .asDriver(onErrorDriveWith: .empty())
         
+        //MARK: ImageCellSubject
         self.deleteCellImage = self.deleteCellImageInput
             .asDriver(onErrorDriveWith: .empty())
         
         self.changeSelectedImage = self.deliverSelectedIndex
             .map{_ in Void() }
             .asDriver(onErrorDriveWith: .empty())
+        
+        //MARK: PinSubject
+        self.deletePin = self.deletePinButtonTap
+            .map{_ in }
+            .asDriver(onErrorDriveWith: .empty())
+        
+        self.addPin = self.addPinButtonTap
+            .map{_ in}
+            .asDriver(onErrorDriveWith: .empty())
+        
+        self.sholudPushPinOption = self.pinTap
+            .asDriver(onErrorDriveWith: .empty())
+        
+        self.sholudPushModifyPinInfo = self.modifyPinOptionButtonTap
+            .asDriver(onErrorDriveWith: .empty())
+        
+        self.dismissModifyInfo = self.pinInfoViewModel
+            .cancelButtonTap
+            .map{ _ in }
+            .asDriver(onErrorDriveWith: .empty())
+        
+        self.dismissModifyInfo = self.pinInfoViewModel
+            .saveButtonTap
+            .map{ _ in}
+            .asDriver(onErrorDriveWith: .empty())
+        
+        self.pinInfoViewModel
+            .saveButtonTap
+            .subscribe(onNext : {[weak self] index in
+                guard let self = self else { return }
+                var pinList = self.pinsRelay.value
+                let productName = pinInfoViewModel.productName.value
+                let purchaseInfo = pinInfoViewModel.purchaseInfo.value
+                let productInfo : ProductInfo = ProductInfo(name: productName, url: purchaseInfo)
+                print("productInfo \(productInfo), index : \(index)")
+                pinList[self.selectedImageIndex][index].productInfo = productInfo
+            })
+            .disposed(by: disposeBag)
+        
+        self.modifyPinOptionButtonTap
+            .subscribe(onNext: {[weak self] index in
+                guard let self = self else { return }
+                self.pinInfoViewModel.index = index
+                self.deliverPinInfoViewModel.accept(self.pinInfoViewModel)
+            })
+            .disposed(by: disposeBag)
+        
+        self.deletePinButtonTap
+            .subscribe(onNext : {[weak self] index in
+                guard let self = self else { return }
+                var pinLinst = self.pinsRelay.value
+                pinLinst.remove(at: index)
+                self.pinsRelay.accept(pinLinst)
+            })
+            .disposed(by: disposeBag)
+        
+        self.pinDragFinish
+            .subscribe(onNext : {[weak self] value in
+                guard let self = self else { return }
+                let pId = value["pId"] as! Int
+                let point = value["point"] as! CGPoint
+                if pId >= 0 {
+                    var pinList = self.pinsRelay.value
+                    let positionX = (point.x - self.imageSize.value.origin.x) / self.imageSize.value.size.width
+                    let positionY = (point.y - self.imageSize.value.origin.y) / self.imageSize.value.size.height
+                    
+                    pinList[self.selectedImageIndex][pId].positionX = positionX
+                    pinList[self.selectedImageIndex][pId].positionY = positionY
+                    self.pinsRelay.accept(pinList)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        self.addPinButtonTap
+            .subscribe(onNext: {[weak self] _ in
+                guard let self = self else { return }
+                let pin = Pin(positionX: 0.5, positionY: 0.5)
+                var pinList = self.pinsRelay.value
+                if pinList.count > self.selectedImageIndex && self.selectedImageIndex >= 0 {
+                    pinList[self.selectedImageIndex].append(pin)
+                    self.pinsRelay.accept(pinList)
+                }
+            })
+            .disposed(by: disposeBag)
+        
+        self.modifyPinButtonTap
+            .subscribe(onNext : {[weak self] pin in
+                guard let self = self else { return }
+                var pinList = self.pinsRelay.value
+                let pinId : Int = pin["pinID"] as! Int
+                let productInfo : ProductInfo = pin["productInfo"] as! ProductInfo
+                pinList[self.selectedImageIndex][pinId].productInfo = productInfo
+            })
+            .disposed(by: disposeBag)
         
         self.deliverSelectedIndex
             .subscribe(onNext : {[weak self] index in
@@ -162,10 +289,10 @@ public class MakePostViewModel : MakePostViewModelProtocol {
             .subscribe(onNext: {[weak self] images in
                 guard let self = self else {return}
                 var tmpViewModel : [SelectedImageViewModelProtocol] = self.selectedImageViewModels.value
+                var tmpPins  = self.pinsRelay.value
                 
                 images.enumerated().forEach { index, image in
                     if self.selectedImageViewModels.value.count <= index {
-                        print(index)
                         let selectedImageViewModel = SelectedImageViewModel(index)
                         tmpViewModel.append(selectedImageViewModel)
                         
@@ -176,14 +303,24 @@ public class MakePostViewModel : MakePostViewModelProtocol {
                         selectedImageViewModel.imageTap
                             .bind(to : self.deliverSelectedIndex)
                             .disposed(by: self.disposeBag)
+                        
+                        tmpPins.append([])
                     }
                 }
+                
+                self.pinsRelay.accept(tmpPins)
                 self.selectedImageViewModels.accept(tmpViewModel)
                 self.selectedImageIndex = images.count - 1
             })
             .disposed(by: disposeBag)
         
-
+        self.contentInput
+            .subscribe(onNext: {[weak self] content in
+                if let content = content {
+                    self?.content.accept(content)
+                }
+            })
+            .disposed(by: disposeBag)
     }
     
     public var sholudPushSelectAlert: Driver<Void>
@@ -191,13 +328,29 @@ public class MakePostViewModel : MakePostViewModelProtocol {
     public var sholudPushImagePicker: Driver<Bool>
     public var deleteCellImage: Driver<Int>
     public var changeSelectedImage: Driver<Void>
+    public var addPin: Driver<Void>
+    public var deletePin: Driver<Void>
+    public var sholudPushPinOption: Driver<Int>
+    public var sholudPushModifyPinInfo: Driver<Int>
+    public var dismissModifyInfo: Driver<Void>
     
     public var cameraTap: PublishSubject<Void>
     public var libraryTap: PublishSubject<Void>
     public var deleteCellImageInput: PublishSubject<Int>
     public var deliverSelectedIndex: PublishSubject<Int>
+    public var addPinButtonTap: PublishSubject<Void>
+    public var pinTap: PublishSubject<Int>
+    public var deletePinButtonTap: PublishSubject<Int>
+    public var modifyPinOptionButtonTap: PublishSubject<Int>
+    public var modifyPinButtonTap: PublishSubject<[String : Any]>
+    public var pinDragFinish: BehaviorSubject<[String : Any]>
+    public var contentInput: PublishSubject<String?>
     
     public var selectedImageRelay: BehaviorRelay<[UIImage]>
     public var selectedImageViewModels: BehaviorRelay<[SelectedImageViewModelProtocol]>
     public var deliverAddImageViewModel: BehaviorRelay<AddImageViewModelProtocol>
+    public var deliverPinInfoViewModel: BehaviorRelay<PinInfoViewModelProtocol>
+    public var pinsRelay: BehaviorRelay<[[Pin]]>
+    public var imageSize: BehaviorRelay<CGRect>
+    public var content: BehaviorRelay<String>
 }

--- a/MyKkumi/MyKkumi/Presentation/Post/MakePostViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/MakePostViewModel.swift
@@ -14,12 +14,14 @@ import AVFoundation
 public protocol MakePostViewModelInput {
     var cameraTap : PublishSubject<Void> { get }
     var libraryTap : PublishSubject<Void> { get }
+    var deleteCellImageInput : PublishSubject<Int> { get }
 }
 
 public protocol MakePostViewModelOutput {
     var sholudPushSelectAlert : Driver<Void> { get }
     var sholudPushImagePicker : Driver<Bool> { get }
     var sholudPushCamera : Driver<Bool> { get }
+    var deleteCellImage : Driver<Bool> { get }
 }
 
 public protocol MakePostViewModelProtocol : MakePostViewModelOutput,  MakePostViewModelInput{
@@ -39,6 +41,7 @@ public class MakePostViewModel : MakePostViewModelProtocol {
         self.deliverAddImageViewModel = BehaviorRelay<AddImageViewModelProtocol>(value: addImageViewModel)
         self.cameraTap = PublishSubject<Void>()
         self.libraryTap = PublishSubject<Void>()
+        self.deleteCellImageInput = PublishSubject<Int>()
         
         self.sholudPushSelectAlert = self.addImageViewModel.addButtonTap
             .asDriver(onErrorDriveWith: .empty())
@@ -97,24 +100,52 @@ public class MakePostViewModel : MakePostViewModelProtocol {
         self.sholudPushCamera = cameraAuth
             .asDriver(onErrorDriveWith: .empty())
         
+        self.deleteCellImage = self.selectedImageRelay
+            .map{ _ in true }
+            .asDriver(onErrorDriveWith: .empty())
+        
+        //이부분에서 그냥 deleteCellimage에 따라서 쪼개고 deletecelliamge는 그와 상관 없이 이벤트 방출하도록 만들면 해결 가능 할드
+        self.deleteCellImageInput
+            .subscribe(onNext : {[weak self] index in
+                guard let self = self else { return }
+                var images = self.selectedImageRelay.value
+                guard index >= 0  && index < images.count else {return }
+
+                images.remove(at: index)
+                self.selectedImageRelay.accept(images)
+
+                var tmpViewModels = self.selectedImageViewModels.value
+                tmpViewModels.remove(at: index)
+                self.selectedImageViewModels.accept(tmpViewModels)
+            })
+            .disposed(by: disposeBag)
+        
         self.selectedImageRelay
             .subscribe(onNext: {[weak self] images in
                 guard let self = self else {return}
                 var tmpViewModel : [SelectedImageViewModelProtocol] = []
-                images.forEach { image in
-                    tmpViewModel.append(SelectedImageViewModel())
+                images.enumerated().forEach { index, image in
+                    let selectedImageViewModel = SelectedImageViewModel(index)
+                    tmpViewModel.append(selectedImageViewModel)
+                    selectedImageViewModel.deleteButtonTap
+                        .map{ index }
+                        .bind(to : self.deleteCellImageInput)
+                        .disposed(by: self.disposeBag)
                 }
                 self.selectedImageViewModels.accept(tmpViewModel)
             })
             .disposed(by: disposeBag)
+
     }
     
     public var sholudPushSelectAlert: Driver<Void>
     public var sholudPushCamera: Driver<Bool>
     public var sholudPushImagePicker: Driver<Bool>
+    public var deleteCellImage: Driver<Bool>
     
     public var cameraTap: PublishSubject<Void>
     public var libraryTap: PublishSubject<Void>
+    public var deleteCellImageInput: PublishSubject<Int>
     
     public var selectedImageRelay: BehaviorRelay<[UIImage]>
     public var selectedImageViewModels: BehaviorRelay<[any SelectedImageViewModelProtocol]>

--- a/MyKkumi/MyKkumi/Presentation/Post/MakePostViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/MakePostViewModel.swift
@@ -33,7 +33,7 @@ public protocol MakePostViewModelOutput {
     var deleteCellImage : Driver<Int> { get }
     var changeSelectedImage : Driver<Void> { get }
     var addPin : Driver<Void> { get }
-    var deletePin : Driver<Void> { get }
+    var deletePin : Driver<Int> { get }
     var sholudPushPinOption : Driver<Int> { get }
     var dismissModifyInfo : Driver<Void> { get }
 }
@@ -147,7 +147,6 @@ public class MakePostViewModel : MakePostViewModelProtocol {
         
         //MARK: PinSubject
         self.deletePin = self.deletePinButtonTap
-            .map{_ in }
             .asDriver(onErrorDriveWith: .empty())
         
         self.addPin = self.addPinButtonTap
@@ -195,7 +194,7 @@ public class MakePostViewModel : MakePostViewModelProtocol {
             .subscribe(onNext : {[weak self] index in
                 guard let self = self else { return }
                 var pinLinst = self.pinsRelay.value
-                pinLinst.remove(at: index)
+                pinLinst[self.selectedImageIndex].remove(at: index)
                 self.pinsRelay.accept(pinLinst)
             })
             .disposed(by: disposeBag)
@@ -329,7 +328,7 @@ public class MakePostViewModel : MakePostViewModelProtocol {
     public var deleteCellImage: Driver<Int>
     public var changeSelectedImage: Driver<Void>
     public var addPin: Driver<Void>
-    public var deletePin: Driver<Void>
+    public var deletePin: Driver<Int>
     public var sholudPushPinOption: Driver<Int>
     public var sholudPushModifyPinInfo: Driver<Int>
     public var dismissModifyInfo: Driver<Void>

--- a/MyKkumi/MyKkumi/Presentation/Post/PinInfoPresentationController.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/PinInfoPresentationController.swift
@@ -1,0 +1,51 @@
+//
+//  PinInfoPresentationController.swift
+//  MyKkumi
+//
+//  Created by 최재혁 on 8/7/24.
+//
+
+import Foundation
+import UIKit
+
+class PinInfoPresentationController : UIPresentationController {
+    
+    override var frameOfPresentedViewInContainerView: CGRect {
+        guard let containerView = containerView else { return .zero }
+        
+        let width = containerView.bounds.width
+        let height : CGFloat = 152
+        let x : CGFloat = .zero
+        let y = containerView.bounds.height - height
+        
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+    
+    override func presentationTransitionWillBegin() {
+        guard let containerView = containerView else { return }
+
+        let dimmingView = UIView(frame: containerView.bounds)
+        dimmingView.backgroundColor = UIColor(white: 0.0, alpha: 0.5)
+        dimmingView.alpha = 0.0
+        
+        containerView.addSubview(dimmingView)
+
+        presentedViewController.transitionCoordinator?.animate(alongsideTransition: { _ in
+            dimmingView.alpha = 1.0
+        })
+        
+    }
+    
+    override func dismissalTransitionWillBegin() {
+        presentedViewController.transitionCoordinator?.animate(alongsideTransition: { _ in
+            self.containerView?.subviews.first?.alpha = 0.0
+        })
+    }
+}
+
+final class PinInfoPresentationControllerDelegate : NSObject, UIViewControllerTransitioningDelegate {
+    
+    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        return PinInfoPresentationController(presentedViewController: presented, presenting: presenting)
+    }
+}

--- a/MyKkumi/MyKkumi/Presentation/Post/PinInfoViewController.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/PinInfoViewController.swift
@@ -1,0 +1,145 @@
+//
+//  PinInfoViewController.swift
+//  MyKkumi
+//
+//  Created by 최재혁 on 8/7/24.
+//
+
+import Foundation
+import UIKit
+
+class PinInfoViewController : BaseViewController<PinInfoViewModelProtocol> {
+    var viewModel : PinInfoViewModelProtocol!
+    
+    override init() {
+        super.init()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func setupHierarchy() {
+        view.addSubview(productNameStack)
+        view.addSubview(purchaseInfoStack)
+        view.addSubview(cancelButton)
+        view.addSubview(saveButton)
+        productNameStack.addArrangedSubview(productNameLabel)
+        productNameStack.addArrangedSubview(productNameTextField)
+        purchaseInfoStack.addArrangedSubview(purchaseInfoLabel)
+        purchaseInfoStack.addArrangedSubview(purchaseTextField)
+    }
+    
+    public override func setupBind(viewModel: PinInfoViewModelProtocol) {
+        self.viewModel = viewModel
+        
+        self.cancelButton.rx.tap
+            .map{ self.viewModel.index }
+            .bind(to: viewModel.cancelButtonTap)
+            .disposed(by: disposeBag)
+        
+        self.saveButton.rx.tap
+            .map { self.viewModel.index }
+            .bind(to: viewModel.saveButtonTap)
+            .disposed(by: disposeBag)
+        
+        self.productNameTextField.rx.text.orEmpty
+            .bind(to: self.viewModel.productName)
+            .disposed(by: disposeBag)
+        
+        self.purchaseTextField.rx.text.orEmpty
+            .bind(to: self.viewModel.purchaseInfo)
+            .disposed(by: disposeBag)
+    }
+    
+    override func setupLayout() {
+        //ProductName
+        NSLayoutConstraint.activate([
+            productNameStack.topAnchor.constraint(equalTo: view.topAnchor, constant: 32),
+            productNameStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 86),
+            productNameStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -86)
+        ])
+        
+        //PurchaseInfo
+        NSLayoutConstraint.activate([
+            purchaseInfoStack.topAnchor.constraint(equalTo: productNameStack.bottomAnchor, constant: 10),
+            purchaseInfoStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 86),
+            purchaseInfoStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -86)
+        ])
+        
+        //Buttons
+        NSLayoutConstraint.activate([
+            cancelButton.topAnchor.constraint(equalTo: purchaseInfoStack.topAnchor, constant: 26),
+            cancelButton.leadingAnchor.constraint(equalTo: view.leadingAnchor,constant: 27),
+            cancelButton.heightAnchor.constraint(equalToConstant: 32),
+            cancelButton.widthAnchor.constraint(equalToConstant: 167)
+        ])
+        
+        NSLayoutConstraint.activate([
+            saveButton.topAnchor.constraint(equalTo: cancelButton.topAnchor),
+            saveButton.leadingAnchor.constraint(equalTo: cancelButton.trailingAnchor, constant: 8),
+            saveButton.heightAnchor.constraint(equalToConstant: 32),
+            saveButton.widthAnchor.constraint(equalToConstant: 167)
+        ])
+    }
+    
+    private var productNameStack : UIStackView  = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 27
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+    
+    private var purchaseInfoStack : UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.spacing = 27
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+    
+    private var productNameLabel : UILabel = {
+        let label = UILabel()
+        label.text = "제품명"
+        label.textColor = .black
+        return label
+    }()
+    
+    private var productNameTextField : UITextField = {
+        let textFeild = UITextField()
+        textFeild.borderStyle = .line
+        textFeild.translatesAutoresizingMaskIntoConstraints = false
+        return textFeild
+    }()
+    
+    private var purchaseInfoLabel : UILabel = {
+        let label = UILabel()
+        label.text = "구매처"
+        label.textColor = .black
+        return label
+    }()
+    
+    private var purchaseTextField : UITextField = {
+        let textFeild = UITextField()
+        textFeild.borderStyle = .line
+        textFeild.translatesAutoresizingMaskIntoConstraints = false
+        return textFeild
+    }()
+    
+    private var cancelButton : UIButton = {
+        let button = UIButton()
+        button.setTitle("취소", for: .normal)
+        button.backgroundColor = .gray
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private var saveButton : UIButton = {
+        let button = UIButton()
+        button.setTitle("저장", for: .normal)
+        button.backgroundColor = .gray
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+}

--- a/MyKkumi/MyKkumi/Presentation/Post/PinInfoViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/PinInfoViewModel.swift
@@ -1,0 +1,63 @@
+//
+//  PinInfoViewModel.swift
+//  MyKkumi
+//
+//  Created by 최재혁 on 8/7/24.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+public protocol PinInfoViewModelInputProtocol {
+    var cancelButtonTap : PublishSubject<Int> { get }
+    var saveButtonTap : PublishSubject<Int> { get }
+    var productNameInput : BehaviorSubject<String> { get }
+    var purchaseInfoInput : BehaviorSubject<String> { get }
+}
+
+public protocol PinInfoViewModelOutputProtocol {
+    
+}
+
+public protocol PinInfoViewModelProtocol : PinInfoViewModelInputProtocol, PinInfoViewModelOutputProtocol{
+    var index : Int { get }
+    var productName : BehaviorRelay<String> { get }
+    var purchaseInfo : BehaviorRelay<String> { get }
+}
+
+public class PinInfoViewModel : PinInfoViewModelProtocol {
+    private let disposeBag  = DisposeBag()
+    public var index: Int
+    
+    public init(_ index : Int) {
+        self.index = index
+        self.productNameInput = BehaviorSubject<String>(value: "")
+        self.purchaseInfoInput = BehaviorSubject<String>(value: "")
+        self.cancelButtonTap = PublishSubject<Int>()
+        self.saveButtonTap = PublishSubject<Int>()
+        self.productName = BehaviorRelay<String> (value: "")
+        self.purchaseInfo = BehaviorRelay<String> (value: "")
+        
+        self.productNameInput
+            .subscribe(onNext: {[weak self] name in
+                self?.productName.accept(name)
+            })
+            .disposed(by: disposeBag)
+        
+        self.purchaseInfoInput
+            .subscribe(onNext: {[weak self] purchase in
+                self?.purchaseInfo.accept(purchase)
+            })
+            .disposed(by: disposeBag)
+        
+    }
+    
+    public var cancelButtonTap: PublishSubject<Int>
+    public var saveButtonTap: PublishSubject<Int>
+    public var productNameInput: BehaviorSubject<String>
+    public var purchaseInfoInput: BehaviorSubject<String>
+    
+    public var productName: BehaviorRelay<String>
+    public var purchaseInfo: BehaviorRelay<String>
+}

--- a/MyKkumi/MyKkumi/Presentation/Post/SelectedImageViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/SelectedImageViewModel.swift
@@ -11,16 +11,18 @@ import RxSwift
 
 public protocol SelectedImageViewModelInput {
     //imageTap은 상위 뷰 모델과 상관없이 그냥 본인의 view에 영향을 주면 될듯
-    var imageTap : PublishSubject<Void> { get }
-    var deleteButtonTap : PublishSubject<Void> { get }
+    var imageTap : PublishSubject<Int> { get }
+    var deleteButtonTap : PublishSubject<Int> { get }
+    var unSelectedCellInput : PublishSubject<Void> { get }
 }
 
 public protocol SelectedImageViewModelOutput {
-    
+    var selectedCell : Driver<Void> { get }
+    var unSelectedCell : Driver<Void> { get }
 }
 
 public protocol SelectedImageViewModelProtocol : SelectedImageViewModelInput, SelectedImageViewModelOutput{
-    
+    var indexPathRow : Int { get set }
 }
 
 public class SelectedImageViewModel : SelectedImageViewModelProtocol {
@@ -29,11 +31,23 @@ public class SelectedImageViewModel : SelectedImageViewModelProtocol {
     
     public init(_ row : Int) {
         self.indexPathRow = row
-        self.imageTap = PublishSubject<Void>()
-        self.deleteButtonTap = PublishSubject<Void>()
+        self.imageTap = PublishSubject<Int>()
+        self.deleteButtonTap = PublishSubject<Int>()
+        self.unSelectedCellInput = PublishSubject<Void>()
+        
+        self.selectedCell = self.imageTap
+            .map{_ in }
+            .asDriver(onErrorDriveWith: .empty())
+        
+        self.unSelectedCell = self.unSelectedCellInput
+            .asDriver(onErrorDriveWith : .empty())
     }
-    private var indexPathRow : Int
+    public var indexPathRow : Int
     
-    public var imageTap: PublishSubject<Void>
-    public var deleteButtonTap: PublishSubject<Void>
+    public var imageTap: PublishSubject<Int>
+    public var deleteButtonTap: PublishSubject<Int>
+    public var unSelectedCellInput: PublishSubject<Void>
+    
+    public var selectedCell: Driver<Void>
+    public var unSelectedCell: Driver<Void>
 }

--- a/MyKkumi/MyKkumi/Presentation/Post/SelectedImageViewModel.swift
+++ b/MyKkumi/MyKkumi/Presentation/Post/SelectedImageViewModel.swift
@@ -10,7 +10,9 @@ import RxCocoa
 import RxSwift
 
 public protocol SelectedImageViewModelInput {
-    
+    //imageTap은 상위 뷰 모델과 상관없이 그냥 본인의 view에 영향을 주면 될듯
+    var imageTap : PublishSubject<Void> { get }
+    var deleteButtonTap : PublishSubject<Void> { get }
 }
 
 public protocol SelectedImageViewModelOutput {
@@ -25,9 +27,13 @@ public class SelectedImageViewModel : SelectedImageViewModelProtocol {
     
     private let disposeBag = DisposeBag()
     
-    public init() {
-        self.selectedImageRelay = BehaviorRelay<[UIImage]>(value: [])
+    public init(_ row : Int) {
+        self.indexPathRow = row
+        self.imageTap = PublishSubject<Void>()
+        self.deleteButtonTap = PublishSubject<Void>()
     }
+    private var indexPathRow : Int
     
-    public var selectedImageRelay: BehaviorRelay<[UIImage]>
+    public var imageTap: PublishSubject<Void>
+    public var deleteButtonTap: PublishSubject<Void>
 }


### PR DESCRIPTION
## 구현내용
### ㅇ 1. 이미지가 선택됨에 따라 viewmodel 추가 생성
- behaviorRelay를 사용하여 이벤트 발생시 image에 대한 viewmodel을 추가로 생성하여 MakePostVM이 소지하도록 하였습니다.
- viewmodel 추가 생성시 해당 event를  MakepostVM에서 처리하도록 진행하였습니다.

### ㅇ 2. 이미시 삭제 선택
- 이미지가 선택, 삭제됨에 따라 화면에 보여지는 Image가 변경되게 하였습니다. 
- 해당 부분에서 심각한 오류가 발생하였으나 원인을 찾지 못하였습니다.

## 고민사항
### ㅇ 1. 특히 이미지 삭제 부분에서의 오류 원인과 정확한 해결 방법을 찾지 못하였습니다.
- 12시간이 넘게 고민하였으나 cell이 삭제되는 경우 이후 새로운 cell을 추가하면 2중 binding이 이루어지는 것과 같은 느낌이 들었습니다.
- 해당 오류로 예상한 이유는 deleteCellInput에 하나의 cell을 선택하였음에도 2번의 이벤트가 발생하여 뒤에 삭제되어서는 안되는 cell까지 함께 삭제되는 오류가 발생했기 때문입니다.

### ㅇ 2. 코드가 너무 지저분해진 느낌이 있습니다.
- collectionView를 사용하다보니 cell이 너무 지저분해지는 느낌이 들었습니다. 
- Collectionview를 사용하지 않고 할 수 있는 방법이 있는지 고민입니다.

## 기타
정말 스스로 힘으로 해결하고 싶었으나 해결하지 못하였습니다.. 해당 부분에 더이상 시간을 사용하면 뒤에 내용을 전혀 다루지 못할 것 같아 우선 PR을 생성하였습니다.🥲